### PR TITLE
Allow `call` and `multicall` to pass `blockTag` as a number or a string

### DIFF
--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -36,7 +36,7 @@ function normalizeParams(params: CallParams): (string | number)[] {
 export async function call(params: {
   target: Address;
   abi: string | any;
-  block?: number;
+  block?: number | string;
   params?: CallParams;
   chain?: Chain;
 }) {
@@ -55,7 +55,7 @@ export async function call(params: {
       to: params.target,
       data: callData,
     },
-    params.block ? `"0x"${params.block.toString(16)}` : "latest"
+    params.block ?? "latest"
   );
   const decodedResult = contractInterface.decodeFunctionResult(
     functionABI,

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -55,7 +55,7 @@ export async function call(params: {
       to: params.target,
       data: callData,
     },
-    params.block ?? "latest"
+    params.block ? `"0x"${params.block.toString(16)}` : "latest"
   );
   const decodedResult = contractInterface.decodeFunctionResult(
     functionABI,

--- a/src/abi/multicall.ts
+++ b/src/abi/multicall.ts
@@ -44,7 +44,7 @@ export default async function makeMultiCall(
     params: any[];
   }[],
   chain: Chain,
-  block?: number
+  block?: number | string
 ) {
   const contractInterface = new ethers.utils.Interface([functionABI]);
   let fd = Object.values(contractInterface.functions)[0];
@@ -85,7 +85,7 @@ async function executeCalls(
     data: string;
   }[],
   chain: Chain,
-  block?: number
+  block?: number | string
 ) {
   if (await networkSupportsMulticall(chain)) {
     try {


### PR DESCRIPTION
Hello, 
I don't know who handles the SDK, but we are using this to build some calls in the backend of the LlamaFolio API. 

Right now, we are trying to make tests for all the adapters, and we require to specify the block height to ensure we fetch balances at a certain point in the chain. We must pass the block number as a number or a string.