### PR TITLE
add boba_avax and boba_bnb providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .env
 node_modules
+.idea

--- a/src/abi/multicall.ts
+++ b/src/abi/multicall.ts
@@ -205,6 +205,10 @@ function multicallAddress(chainId: number) {
       return "0x5e954f5972EC6BFc7dECd75779F10d848230345F"; // cronos
     case 288:
       return "0x80Ae459D058436ecB4e043ac48cfd209B578CBF0"; // boba
+    case 43288:
+      return "0x92C5b5B66988E6B8931a8CD3faa418b42003DF2F"; // boba
+    case 56288:
+      return "0x31cCe73DA4365342bd081F6a748AAdb7c7a49b7E"; // boba
     case 4689:
       return "0x5a6787fc349665c5b0c4b93126a0b62f14935731"; // iotex
     case 82:

--- a/src/general.ts
+++ b/src/general.ts
@@ -68,6 +68,8 @@ export const providers = {
   aurora: createProvider("aurora", "https://mainnet.aurora.dev", 1313161554),
   ronin: createProvider("ronin", "https://api.roninchain.com/rpc", 2020),
   boba: createProvider("boba", "https://mainnet.boba.network/", 288),
+  boba_avax: createProvider("boba_avax", "https://avax.boba.network/", 43288),
+  boba_bnb: createProvider("boba_bnb", "https://bnb.boba.network/", 56288),
   cronos: createProvider("cronos", "https://cronosrpc-1.xstaking.sg,https://evm.cronos.org,https://rpc.vvs.finance,https://evm-cronos.crypto.org", 25),
   polis: createProvider("polis", "https://rpc.polis.tech", 333999),
   zyx: createProvider("zyx", "https://rpc-6.zyx.network,https://rpc-4.zyx.network,https://rpc-1.zyx.network/,https://rpc-2.zyx.network/,https://rpc-3.zyx.network/,https://rpc-5.zyx.network/", 55),
@@ -181,6 +183,8 @@ export type Chain =
   | "aurora"
   | "ronin"
   | "boba"
+  | "boba_avax"
+  | "boba_bnb"
   | "cronos"
   | "polis"
   | "zyx"


### PR DESCRIPTION
Hi!

Could you review and merge this pull request that add two new networks: BOBA_BNB and BOBA_AVAX?

These networks are required to build new symbiosis-finance V2 adapter.

Thanks