### PR TITLE
Add SEI EVM chain provider

### DIFF
--- a/src/abi/multicall.ts
+++ b/src/abi/multicall.ts
@@ -385,6 +385,8 @@ function multicallAddress(chainId: number | BigInt) {
       return '0x493d616f5F9a64e5B3D527120E406439bdF29272';
     case 810180:  // zklink
       return '0xa8738F57538E3Bb73872d1133F2358c7Fe56FD35';
+    case 1329: // sei
+      return '0x51aA24A9230e62CfaF259c47DE3133578cE36317';
     default:
       return null;
   }

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -113,6 +113,7 @@ const DEPLOYMENT_BLOCK = {
   bitr: 1045566,
   dreyerx: 163720,
   cyeth: 1,
+  sei: 79351444,
 } as {
   [key: string | Chain]: number
 }

--- a/src/providers.json
+++ b/src/providers.json
@@ -1091,5 +1091,11 @@
       "https://real.drpc.org"
     ],
     "chainId": 111188
+  },
+  "sei": {
+    "rpc": [
+      "https://evm-rpc.sei-apis.com"
+    ],
+    "chainId": 1329
   }
 }


### PR DESCRIPTION
# Add SEI Native EVM chain (pacific-1)

- Add SEI EVM [Multicall1](https://seitrace.com/address/0x51aA24A9230e62CfaF259c47DE3133578cE36317?chain=pacific-1) address
- Add SEI EVM [Multicall3](https://seitrace.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?chain=pacific-1) fromBlock
- Add [SEI EVM RPC](https://sei-apis.com) and [chainId](https://www.docs.sei.io/dev-chains)

Feel free to edit/change as you need, thank you! cc @0xngmi