### PR TITLE
fix(providers): add "nibiru" as chain with chainId 6900 to match ethereum-lists/chains

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -719,5 +719,12 @@
     ],
     "chainId": 42793,
     "explorer": "https://explorer.etherlink.com"
+  },
+  "nibiru": {
+    "rpc": [
+      "https://evm-rpc.nibiru.fi"
+    ],
+    "chainId": 6900,
+    "explorer": "https://nibiscan.io"
   }
 }


### PR DESCRIPTION
## Purpose

Adds Nibiru to "providers.json" to accurately propagate its EVM RPC endpoint and
chainId of 6900.

## Rationale

Several TVL Adapters are blocked by "nibiru":
1. missing its `chainId` field on the `ChainApi` (api) object,
2. and having the default value of 400069 as the `chainId` on the `LlamaProvider`

This can be seen from console logging the `api` object in the downstream repos.
For example, this is from the `uniV3Export` helper in the adapters repo:

```js
// DEBUG uniV3Export forEach 
{
  chain: 'nibiru',
  fromBlock: 19674297,
  api: <ref *1> ChainApi {
    block: undefined,
    chain: 'nibiru',
    timestamp: 1747982188,
    provider: LlamaProvider {
      quorum: 1,
      eventQuorum: 1,
      eventWorkers: 1,
      isCustomLlamaProvider: true,
      rpcs: [
        {
          url: 'https://evm-rpc.nibiru.fi',
          provider: JsonRpcProvider {}
        },
        [length]: 1
      ],
      archivalRPCs: [ [length]: 0 ],
      chainName: 'nibiru',
      chainId: 400069,
      _isReady: Promise { undefined },
      [providerConfigs]: [Getter],
      [pollingInterval]: [Getter],
      [provider]: [Getter],
      [plugins]: [Getter],
      [disableCcipRead]: [Getter/Setter],
      [destroyed]: [Getter],
      [paused]: [Getter/Setter]
    },
    _balances: Balances { chain: 'nibiru', timestamp: 1747982188, _balances: {} },
    chainId: undefined,
    storedKey: 'nibiru',
    api: [Circular *1]
  }
}: 
```

The Point: THe RPC is being picked up from ethereum-lists/chains, but the `chainId` is not.
