### PR TITLE
Add option to store cache in uncompressed format

### DIFF
--- a/src/generalUtil.ts
+++ b/src/generalUtil.ts
@@ -2,7 +2,7 @@ import * as blocks from "./computeTVL/blocks";
 import * as humanizeNumber from "./computeTVL/humanizeNumber";
 import type { Balances, StringNumber, Address } from "./types";
 import * as ethers from 'ethers'
-export { sliceIntoChunks, normalizeAddress, getTimestamp, } from "./util";
+export { sliceIntoChunks, normalizeAddress, getTimestamp, tableToString, } from "./util";
 
 // We ignore `sum` as it's never used (only in some SDK wrapper code)
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,6 +46,7 @@ test("imports", async () => {
           "normalizePrefixes": [Function],
           "runInPromisePool": [Function],
           "sliceIntoChunks": [Function],
+          "tableToString": [Function],
         },
       },
       "api2": {
@@ -84,6 +85,7 @@ test("imports", async () => {
           "normalizePrefixes": [Function],
           "runInPromisePool": [Function],
           "sliceIntoChunks": [Function],
+          "tableToString": [Function],
         },
       },
       "blocks": {
@@ -237,6 +239,7 @@ test("imports", async () => {
         "sumChainTvls": [Function],
         "sumMultiBalanceOf": [Function],
         "sumSingleBalance": [Function],
+        "tableToString": [Function],
       },
     }
   `);

--- a/src/util/cache.test.ts
+++ b/src/util/cache.test.ts
@@ -23,7 +23,7 @@ test("Cache - parseCache & compressCache", async () => {
 test("Cache r2 - Write Object", async () => {
   const testFile = 'unit-test/object.json'
   const inputData = { test: 'this is a string' }
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
 
   await writeCache(testFile, inputData)
 
@@ -34,7 +34,7 @@ test("Cache r2 - Write Object", async () => {
 
 test("Cache - Read R2 Object", async () => {
   const testFile = 'unit-test/object.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
   const data = await getR2JSONString(currentVersion + '/' + testFile)
   const parsedData = await parseCache(data)
   expect(parsedData.test).toEqual('this is a string')
@@ -42,7 +42,7 @@ test("Cache - Read R2 Object", async () => {
 
 test("Cache - write string", async () => {
   const testFile = 'unit-test/string.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
   const stringData = 'this is a string; Lopum ipsum dolor sit amet, consectetur adipiscing elit. Nulla euismod, nisl eget aliquam ultricies, nisl nisl aliquet nisl, nec aliquam nisl nisl nec.'
 
   await writeCache(testFile, stringData)
@@ -55,7 +55,7 @@ test("Cache - write string", async () => {
 
 test("Cache - write large file", async () => {
   const testFile = 'unit-test/large-file.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
   const largeData = [0, 1, 2, 3, 4, 5].map(_ => largeMulticall)
 
   await writeCache(testFile, largeData)
@@ -69,7 +69,7 @@ test("Cache - write large file", async () => {
 
 test("write cache: empty object", async () => {
   const testFile = 'unit-test/empty-file.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
 
   await writeCache(testFile, {})
   let data = await readCache(testFile)
@@ -103,7 +103,7 @@ test("write cache: empty object", async () => {
 
 test("Cache - write string - uncompressed", async () => {
   const testFile = 'unit-test/string.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
   const stringData = 'this is a string; Lopum ipsum dolor sit amet, consectetur adipiscing elit. Nulla euismod, nisl eget aliquam ultricies, nisl nisl aliquet nisl, nec aliquam nisl nisl nec.'
 
   await writeCache(testFile, stringData, { skipCompression: true })
@@ -114,7 +114,7 @@ test("Cache - write string - uncompressed", async () => {
 
 test("Cache - write large file - uncompressed", async () => {
   const testFile = 'unit-test/large-file-uncompressed.json'
-  deleteCacheSwallowError(testFile)
+  await deleteCacheSwallowError(testFile)
   const largeData = [0, 1, 2, 3, 4, 5].map(_ => largeMulticall)
 
   await writeCache(testFile, largeData, { skipCompression: true })

--- a/src/util/cache.test.ts
+++ b/src/util/cache.test.ts
@@ -1,7 +1,16 @@
 
 import largeMulticall from '../abi/largeMulticall';
-import { writeCache, readCache, parseCache, compressCache, currentVersion, } from './cache';
+import { writeCache, readCache, parseCache, compressCache, currentVersion, deleteCache, } from './cache';
 import { getR2JSONString } from './r2';
+
+// Swallow error for testing purposes
+async function deleteCacheSwallowError(file: string, throwError = false) {
+  try {
+    await deleteCache(file);
+  } catch (error) {
+    if (throwError) throw error;
+  }
+}
 
 test("Cache - parseCache & compressCache", async () => {
   const inputData = { test: 'this is a string' }
@@ -14,16 +23,18 @@ test("Cache - parseCache & compressCache", async () => {
 test("Cache r2 - Write Object", async () => {
   const testFile = 'unit-test/object.json'
   const inputData = { test: 'this is a string' }
+  deleteCacheSwallowError(testFile)
 
   await writeCache(testFile, inputData)
 
   const data = await readCache(testFile)
   expect(data.test).toEqual(inputData.test)
-
+  await deleteCacheSwallowError(testFile, true)
 })
 
 test("Cache - Read R2 Object", async () => {
   const testFile = 'unit-test/object.json'
+  deleteCacheSwallowError(testFile)
   const data = await getR2JSONString(currentVersion + '/' + testFile)
   const parsedData = await parseCache(data)
   expect(parsedData.test).toEqual('this is a string')
@@ -31,17 +42,20 @@ test("Cache - Read R2 Object", async () => {
 
 test("Cache - write string", async () => {
   const testFile = 'unit-test/string.json'
+  deleteCacheSwallowError(testFile)
   const stringData = 'this is a string; Lopum ipsum dolor sit amet, consectetur adipiscing elit. Nulla euismod, nisl eget aliquam ultricies, nisl nisl aliquet nisl, nec aliquam nisl nisl nec.'
 
   await writeCache(testFile, stringData)
 
   const data = await readCache(testFile)
   expect(data).toEqual(stringData)
+  await deleteCacheSwallowError(testFile, true)
 })
 
 
 test("Cache - write large file", async () => {
   const testFile = 'unit-test/large-file.json'
+  deleteCacheSwallowError(testFile)
   const largeData = [0, 1, 2, 3, 4, 5].map(_ => largeMulticall)
 
   await writeCache(testFile, largeData)
@@ -49,11 +63,13 @@ test("Cache - write large file", async () => {
   const data = await readCache(testFile)
   expect(data.length).toBe(6)
   expect(data[0].calls.length).toBeGreaterThan(100)
+  await deleteCacheSwallowError(testFile, true)
 })
 
 
 test("write cache: empty object", async () => {
   const testFile = 'unit-test/empty-file.json'
+  deleteCacheSwallowError(testFile)
 
   await writeCache(testFile, {})
   let data = await readCache(testFile)
@@ -70,4 +86,49 @@ test("write cache: empty object", async () => {
   await writeCache(testFile, '')
   data = await readCache(testFile)
   expect(data).toEqual({})
-}) 
+
+
+  await writeCache(testFile, undefined, { skipCompression: true })
+  data = await readCache(testFile, { skipCompression: true })
+  expect(data).toEqual({})
+
+  await writeCache(testFile, 'tiny', { skipCompression: true })
+  data = await readCache(testFile, { skipCompression: true })
+  expect(data).toEqual({})
+
+  await writeCache(testFile, '', { skipCompression: true })
+  data = await readCache(testFile, { skipCompression: true })
+  expect(data).toEqual({})
+})
+
+test("Cache - write string - uncompressed", async () => {
+  const testFile = 'unit-test/string.json'
+  deleteCacheSwallowError(testFile)
+  const stringData = 'this is a string; Lopum ipsum dolor sit amet, consectetur adipiscing elit. Nulla euismod, nisl eget aliquam ultricies, nisl nisl aliquet nisl, nec aliquam nisl nisl nec.'
+
+  await writeCache(testFile, stringData, { skipCompression: true })
+
+  const data = await readCache(testFile, { skipCompression: true })
+  expect(data).toEqual(stringData)
+})
+
+test("Cache - write large file - uncompressed", async () => {
+  const testFile = 'unit-test/large-file-uncompressed.json'
+  deleteCacheSwallowError(testFile)
+  const largeData = [0, 1, 2, 3, 4, 5].map(_ => largeMulticall)
+
+  await writeCache(testFile, largeData, { skipCompression: true })
+
+  const data = await readCache(testFile, { skipCompression: true })
+  expect(data.length).toBe(6)
+  expect(data[0].calls.length).toBeGreaterThan(100)
+})
+
+
+test("Cache - parseCache & compressCache - uncompressed", async () => {
+  const inputData = { test: 'this is a string' }
+
+  const compressedData = await compressCache(inputData, { skipCompression: true })
+  expect((await parseCache(compressedData.toString('base64'), { skipCompression: true })).test).toEqual(inputData.test)
+  expect((await parseCache(compressedData, { skipCompression: true })).test).toEqual(inputData.test)
+})

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -130,14 +130,18 @@ export async function writeCache(file: string, data: any, options: WriteCacheOpt
 export async function parseCache(dataString: string | Buffer, options: ReadCacheOptions = {}) {
   let dataBuffer: Buffer
   if (typeof dataString === 'string') dataBuffer = Buffer.from(dataString, 'base64')
+  else {
+    dataBuffer = dataString as Buffer
+    dataString = dataBuffer.toString('utf8')
+  }
   let decompressed: any
 
-  let _unzipAsync = (str: Buffer) => options.skipCompression ?  dataString : unzipAsync(str)  // if skipCompression is true, we don't decompress the data
+  let _unzipAsync = (str: Buffer) => options.skipCompression ? dataString : unzipAsync(str)  // if skipCompression is true, we don't decompress the data
 
   try {
     decompressed = await _unzipAsync(dataBuffer! ?? dataString)
   } catch (e) {
-    dataString = dataString.toString('utf8')
+    // dataString = dataString.toString('utf8')
     const convertedDataString = Buffer.from(dataString, 'base64')
     decompressed = await _unzipAsync(convertedDataString)
   }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -165,3 +165,40 @@ export function normalizeBalances(balances: { [address: string]: string }) {
 
   return balances;
 }
+
+export function tableToString(data: any, columns?: any) {
+  let tableString = '';
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return '';
+  }
+  if (!columns || !Array.isArray(columns) || columns.length === 0) {
+    columns = Object.keys(data[0] || {});
+  }
+
+  // Add the header row
+  const headerObject: any = {}
+  const headerObject1: any = {}
+  columns.forEach((col: any) => {
+    headerObject[col] = col
+    headerObject1[col] = '---'
+  })
+  data.unshift(headerObject1)
+  data.unshift(headerObject)
+  // Calculate the maximum width for each column
+  const columnWidths = columns.map((col: any) => 
+    Math.max(col.length, ...data.map((row: any) => (row[col] !== undefined ? String(row[col]).length : 0)))
+  );
+
+  // Add the data rows
+  data.forEach((row: any) => {
+
+    // Format the row with padded values
+    const tableRow = columns.map((col: any, index: number) => {
+      const cell = row[col] !== undefined ? String(row[col]) : '';
+      return cell.padEnd(columnWidths[index], ' ');
+    }).join(' | ');
+    tableString += tableRow + '\n';
+  });
+
+  return tableString;
+}

--- a/src/util/logs.ts
+++ b/src/util/logs.ts
@@ -209,8 +209,8 @@ export async function getLogs(options: GetLogsOptions): Promise<EventLog[] | Eve
     })
     caches = mergedCaches
 
-    if (!skipCache)
-      await writeCache(getFile(), { caches, version: currentVersion }, { skipR2CacheWrite: !cacheInCloud })
+    if (!skipCache)  // we are skipping compression by default, so reads & writes are faster
+      await writeCache(getFile(), { caches, version: currentVersion }, { skipR2CacheWrite: !cacheInCloud, skipCompression: !cacheInCloud })
   }
 
   function dedupLogs(...logs: EventLog[][]) {
@@ -233,7 +233,7 @@ export async function getLogs(options: GetLogsOptions): Promise<EventLog[] | Eve
 
     if (skipCache) return defaultRes
 
-    let cache = await readCache(key, { skipR2Cache: !cacheInCloud })
+    let cache = await readCache(key, { skipR2Cache: !cacheInCloud, skipCompression: !cacheInCloud, })
 
     if (!cache.caches || !cache.caches.length || cache.version !== currentVersion)
       return defaultRes


### PR DESCRIPTION
Introduce a new option to skip compression when writing to and reading from the cache, enhancing performance for local cache usage. This change allows for faster operations at the cost of increased storage space.