### PR TITLE
fix(#162): <CHAIN>_RPC env var replaces defaults; add runtime RPC quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ ETHEREUM_RPC="https://..."
 BSC_RPC="https://..."
 ```
 
+### Per-chain RPC environment variables
+
+For each EVM chain `<CHAIN>` (lowercase chain key as listed in
+`providers.json`), the following env vars are recognised. Names are case-
+insensitive and may also be prefixed with `LLAMA_SDK_` or `SDK_`.
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `<CHAIN>_RPC` | Comma-separated list of RPC URLs for the chain. **Replaces** the bundled defaults from `providers.json`. | (defaults from `providers.json`) |
+| `<CHAIN>_RPC_APPEND` | If `true`, `<CHAIN>_RPC` is appended to the bundled defaults instead of replacing them (legacy behaviour). | `false` |
+| `<CHAIN>_WHITELISTED_RPC` | Comma-separated list. When set, only these RPCs are used (ignores `<CHAIN>_RPC` and defaults). | unset |
+| `<CHAIN>_ARCHIVAL_RPC` | Comma-separated list of archival RPCs used for `getLogs` and historical calls. | unset |
+| `<CHAIN>_RPC_CHAIN_ID` | Override the chain id reported by the SDK (rarely needed). | from `providers.json` |
+| `<CHAIN>_RPC_MULTICALL` | Override the multicall contract address. | bundled per-chain default |
+| `<CHAIN>_RPC_MAX_PARALLEL` | Max concurrent RPC requests for the chain. | `MAX_PARALLEL` (`100`) |
+| `<CHAIN>_RPC_GET_LOGS_CONCURRENCY_LIMIT` | Max concurrent `getLogs` calls. | `GET_LOGS_CONCURRENCY_LIMIT` (`25`) |
+| `<CHAIN>_RPC_GET_BLOCKS_CONCURRENCY_LIMIT` | Max concurrent `getBlock` calls. | `GET_BLOCKS_CONCURRENCY_LIMIT` (`5`) |
+| `<CHAIN>_BATCH_MAX_COUNT` | Max JSON-RPC batch size. | `BATCH_MAX_COUNT` (`5`) |
+| `<CHAIN>_MULTICALL_CHUNK_SIZE` | Calls per multicall chunk. | `MULTICALL_CHUNK_SIZE` (`300`) |
+
+Global RPC tuning:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `LLAMA_SDK_RPC_QUARANTINE_THRESHOLD` | Consecutive failures before an RPC URL is quarantined. | `5` |
+| `LLAMA_SDK_RPC_QUARANTINE_MS` | How long (ms) a quarantined RPC is skipped. | `600000` (10 min) |
+| `SKIP_BLOCK_VALIDATION_CHAINS` | Comma-separated chain keys for which to skip the startup block-height validation. | unset |
+| `RPC_NO_PLAYING_AROUND` | If `true`, always try the primary RPC first (no shuffling). | `false` |
+
 ## Chain RPC PR
 
 Before putting up a PR for new chain, check if we already support it here: https://unpkg.com/@defillama/sdk@latest/build/providers.json 

--- a/src/util/LlamaProvider.quarantine.test.ts
+++ b/src/util/LlamaProvider.quarantine.test.ts
@@ -1,0 +1,69 @@
+import {
+  isRPCQuarantined,
+  recordRPCFailure,
+  recordRPCSuccess,
+  _resetRPCQuarantineForTests,
+} from './LlamaProvider'
+
+beforeEach(() => {
+  _resetRPCQuarantineForTests()
+})
+
+test("RPC is not quarantined by default", () => {
+  expect(isRPCQuarantined('https://fresh.example')).toBe(false)
+})
+
+test("RPC is quarantined after threshold consecutive failures", () => {
+  const url = 'https://dead.example'
+  // Default threshold is 5; record 5 failures.
+  for (let i = 0; i < 5; i++) recordRPCFailure(url)
+  expect(isRPCQuarantined(url)).toBe(true)
+})
+
+test("a single success below threshold resets the failure counter", () => {
+  const url = 'https://flaky.example'
+  for (let i = 0; i < 4; i++) recordRPCFailure(url)
+  expect(isRPCQuarantined(url)).toBe(false)
+  recordRPCSuccess(url)
+  // After success, even 4 more failures should not quarantine (counter reset)
+  for (let i = 0; i < 4; i++) recordRPCFailure(url)
+  expect(isRPCQuarantined(url)).toBe(false)
+})
+
+test("quarantine expires after the configured duration", () => {
+  const url = 'https://dead2.example'
+  const realNow = Date.now
+  let now = 1_700_000_000_000
+  Date.now = () => now
+
+  try {
+    for (let i = 0; i < 5; i++) recordRPCFailure(url)
+    expect(isRPCQuarantined(url)).toBe(true)
+
+    // advance past default 10-minute quarantine
+    now += 10 * 60 * 1000 + 1
+    expect(isRPCQuarantined(url)).toBe(false)
+  } finally {
+    Date.now = realNow
+  }
+})
+
+test("quarantine does not double-extend on further failures during the window", () => {
+  const url = 'https://dead3.example'
+  const realNow = Date.now
+  let now = 1_700_000_000_000
+  Date.now = () => now
+
+  try {
+    for (let i = 0; i < 5; i++) recordRPCFailure(url)
+    expect(isRPCQuarantined(url)).toBe(true)
+
+    // more failures during quarantine should not push the deadline further out
+    for (let i = 0; i < 10; i++) recordRPCFailure(url)
+
+    now += 10 * 60 * 1000 + 1
+    expect(isRPCQuarantined(url)).toBe(false)
+  } finally {
+    Date.now = realNow
+  }
+})

--- a/src/util/LlamaProvider.ts
+++ b/src/util/LlamaProvider.ts
@@ -25,6 +25,39 @@ type ProviderConfigMap = {
 
 const rpcRequestCounter = {} as Record<string, number>
 
+const RPC_QUARANTINE_THRESHOLD = +(process.env.LLAMA_SDK_RPC_QUARANTINE_THRESHOLD ?? 5)
+const RPC_QUARANTINE_MS = +(process.env.LLAMA_SDK_RPC_QUARANTINE_MS ?? 10 * 60 * 1000)
+const rpcFailureCount = {} as Record<string, number>
+const rpcQuarantineUntil = {} as Record<string, number>
+
+export function isRPCQuarantined(url: string): boolean {
+  const until = rpcQuarantineUntil[url]
+  if (!until) return false
+  if (Date.now() >= until) {
+    delete rpcQuarantineUntil[url]
+    rpcFailureCount[url] = 0
+    return false
+  }
+  return true
+}
+
+export function recordRPCFailure(url: string): void {
+  rpcFailureCount[url] = (rpcFailureCount[url] ?? 0) + 1
+  if (rpcFailureCount[url] >= RPC_QUARANTINE_THRESHOLD && !rpcQuarantineUntil[url]) {
+    rpcQuarantineUntil[url] = Date.now() + RPC_QUARANTINE_MS
+    debugLog(`Quarantining RPC ${url} for ${RPC_QUARANTINE_MS}ms after ${rpcFailureCount[url]} consecutive failures`)
+  }
+}
+
+export function recordRPCSuccess(url: string): void {
+  if (rpcFailureCount[url]) rpcFailureCount[url] = 0
+}
+
+export function _resetRPCQuarantineForTests(): void {
+  for (const k of Object.keys(rpcFailureCount)) delete rpcFailureCount[k]
+  for (const k of Object.keys(rpcQuarantineUntil)) delete rpcQuarantineUntil[k]
+}
+
 
 export class LlamaProvider extends FallbackProvider {
   isCustomLlamaProvider = true
@@ -148,6 +181,12 @@ export class LlamaProvider extends FallbackProvider {
 
     runners = runners.slice(0, attempts)
 
+    // Skip RPCs currently in quarantine. If every candidate is quarantined,
+    // fall back to trying them anyway so we never hard-fail purely due to
+    // quarantine state — better to make a best-effort attempt.
+    const liveRunners = runners.filter(r => !isRPCQuarantined(r.url))
+    if (liveRunners.length) runners = liveRunners
+
     // print stats every 5 minutes
     let currentTimeMS = Date.now()
     if (currentTimeMS - lastPrintTimeMS > 1000 * 60 * 5) {
@@ -165,9 +204,11 @@ export class LlamaProvider extends FallbackProvider {
     for (const runner of runners) {
       try {
         const result = await (httpRPC as any)[method](runner.url, params)
+        recordRPCSuccess(runner.url)
         return result
       } catch (e: any) {
         // console.log('failed', runner.url, (e as any).message)
+        recordRPCFailure(runner.url)
         errors.push({ host: runner.url, error: (e?.message ?? e) })
       }
     }

--- a/src/util/env.test.ts
+++ b/src/util/env.test.ts
@@ -169,3 +169,26 @@ test("getChainRPCs", async () => {
   expect(chainRPCsAfter).toBe('http://localhost:8545,http://localhost:8546') // value from process.env
   delete process.env['TESTCHAIN_RPC'];
 });
+
+test("getChainRPCs with default list and no env var returns defaults", async () => {
+  const defaults = ['https://default-1.example', 'https://default-2.example']
+  expect(getChainRPCs("testchain", defaults)).toBe(defaults.join(','))
+});
+
+test("getChainRPCs env var replaces defaults (issue #162)", async () => {
+  // Repro: user sets POLYGON_RPC but the SDK still hits dead default RPCs.
+  // Expectation: when <CHAIN>_RPC is set, the env value REPLACES the default list.
+  process.env['TESTCHAIN_RPC'] = 'http://user.example';
+  const defaults = ['http://dead-rpc.example', 'http://another-dead.example']
+  expect(getChainRPCs("testchain", defaults)).toBe('http://user.example')
+  delete process.env['TESTCHAIN_RPC'];
+});
+
+test("getChainRPCs with <CHAIN>_RPC_APPEND=true preserves legacy merge behaviour", async () => {
+  process.env['TESTCHAIN_RPC'] = 'http://user.example';
+  process.env['TESTCHAIN_RPC_APPEND'] = 'true';
+  const defaults = ['http://default.example']
+  expect(getChainRPCs("testchain", defaults)).toBe('http://user.example,http://default.example')
+  delete process.env['TESTCHAIN_RPC'];
+  delete process.env['TESTCHAIN_RPC_APPEND'];
+});

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -114,6 +114,9 @@ export function getArchivalRPCs(chain: string): string[] {
 
 export function getChainRPCs(chain: string, defaultList: string[] = []): string | undefined {
   const envValue = getEnvRPC(chain)
+  // When <CHAIN>_RPC is set, replace the default list. Set <CHAIN>_RPC_APPEND=true
+  // to keep the legacy behaviour of appending defaults to the user-provided list.
+  if (envValue && !getBoolEnvValue(`${chain}_RPC_APPEND`, false)) return envValue
   if (defaultList.length) {
     const listString = defaultList.join(',')
     if (envValue) return envValue + ',' + listString


### PR DESCRIPTION
## Bug
`<CHAIN>_RPC` was appending the user's URL to bundled defaults instead of replacing them, so dead
defaults (e.g. `rpc-mainnet.maticvigil.com`) kept being tried even when a working RPC was set.

## Changes
- **`src/util/env.ts`** — `<CHAIN>_RPC` now replaces defaults. Use `<CHAIN>_RPC_APPEND=true` to
  restore the old merge behaviour.
- **`src/util/LlamaProvider.ts`** — RPCs that fail `LLAMA_SDK_RPC_QUARANTINE_THRESHOLD` times
  (default 5) are quarantined for `LLAMA_SDK_RPC_QUARANTINE_MS` (default 10 min). Falls back to
  trying all URLs if everything is quarantined.
- **`README.md`** — added reference table for all `<CHAIN>_*` env vars and quarantine vars.

## Tests
8 new unit tests covering: RPC replace/append behaviour, quarantine threshold, expiry, and reset
on success. `tsc --noEmit` clean. Pre-existing failures in `index.test.ts` are unrelated.

## Breaking change
`<CHAIN>_RPC` now replaces defaults instead of merging. Add `<CHAIN>_RPC_APPEND=true` to opt in
to the old behaviour.