### PR TITLE
providers: add official Tempo Mainnet RPC

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -780,5 +780,12 @@
     ],
     "chainId": 2910,
     "explorer": "https://explorer.morphl2.io"
+  },
+  "tempo": {
+    "rpc": [
+      "https://rpc.mainnet.tempo.xyz"
+    ],
+    "chainId": 4217,
+    "explorer": "https://explore.mainnet.tempo.xyz"
   }
 }


### PR DESCRIPTION
## Summary

Adds an entry for **Tempo Mainnet "Presto"** (chainId 4217) to `src/providers.json` so that the official chain RPC is included in the merged provider list.

```diff
+  "tempo": {
+    "rpc": [
+      "https://rpc.mainnet.tempo.xyz"
+    ],
+    "chainId": 4217,
+    "explorer": "https://explore.mainnet.tempo.xyz"
+  }
```

## Why

`src/util/updateProviderList.ts` merges `src/providers.json` entries with chainlist.org data by chainId. Today there's no Tempo entry in `src/providers.json`, so the published `build/providers.json` only carries chainlist's single entry (`https://tempo-mainnet.drpc.org`). That single endpoint empirically can't keep up with concurrent `multiCall(permitFailure: true)` patterns used by some adapters — it returns undefined responses that the SDK then chokes on at `abi/index.js:205` (filter on `.success`).

Adding the official RPC (per [docs.tempo.xyz/quickstart/network](https://docs.tempo.xyz/quickstart/network)) means the merged list will be:

```json
[
  "https://rpc.mainnet.tempo.xyz",
  "https://tempo-mainnet.drpc.org"
]
```

(`rpc.mainnet.tempo.xyz` — new, priority from src; `tempo-mainnet.drpc.org` — retained, chainlist append.)

Brings Tempo's redundancy in line with similarly recent EVM L1s already in `src/providers.json`:
- sonic — 7 RPCs
- katana — 4 RPCs
- plasma / soneium — 3 RPCs each

## Verification

```
$ curl -sX POST -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","id":1}' \
    https://rpc.mainnet.tempo.xyz
{"jsonrpc":"2.0","id":1,"result":"0x1079"}
```

`0x1079` = 4217 — matches the chainId field. Endpoint healthy as of 2026-04-30.

## Companion PRs (chain integration depends on this)

- [DefiLlama-Adapters #19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015) — Tempo TVL coverage — **open**
- [peggedassets-server #773](https://github.com/DefiLlama/peggedassets-server/pull/773) — pathUSD pegged + 9 stablecoin Tempo extends — **open**
- [dimension-adapters #6682](https://github.com/DefiLlama/dimension-adapters/pull/6682) — Fee AMM protocol fees adapter — ✅ **merged 2026-05-02**
- [bridges-server #478](https://github.com/DefiLlama/bridges-server/pull/478) — Stargate v2 Tempo OFT spoke bridge volume — ✅ **merged 2026-05-01**

Once this is merged, a follow-up will re-add the Stargate v2 Tempo entry to `dimension-adapters/fees/stargate-finance-v2` (omitted from #6682 due to the single-RPC issue this PR fixes).
