### PR TITLE
Add Gensyn Mainnet (chainId: 685689) RPC configuration

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -780,5 +780,12 @@
     ],
     "chainId": 2910,
     "explorer": "https://explorer.morphl2.io"
+  },
+  "gensyn": {
+    "rpc": [
+      "https://gensyn-mainnet.g.alchemy.com/public"
+    ],
+    "chainId": 685689,
+    "explorer": "https://gensyn-mainnet.explorer.alchemy.com"
   }
 }


### PR DESCRIPTION
## Summary
- Add Gensyn Mainnet (Chain ID: 685689) to `providers.json`
- Public Alchemy RPC endpoint and Blockscout-style explorer

## Context
Gensyn Mainnet is an EVM-compatible OP-stack L2 (live since 2026-04-29). This registration is needed to enable on-chain adapter support for protocols deployed on Gensyn Mainnet, starting with [Delphi](https://app.delphi.fyi) and the AI/USDC.e Uniswap V3 pool.

## Changes
- `src/providers.json`: Added `gensyn` entry with RPC URL and chainId 685689