### PR TITLE
Add XO provider with RPC and chainId

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -780,5 +780,11 @@
     ],
     "chainId": 2910,
     "explorer": "https://explorer.morphl2.io"
+  },
+  "xo": {
+    "rpc": [
+      "https://rpc-mainnet-2.xo.market/"
+    ],
+    "chainId": 3223
   }
 }


### PR DESCRIPTION
Adds XO Market (chain id 3223), a Celestia-based EVM rollup. RPC: https://rpc-mainnet-2.xo.market/