### PR TITLE
Added EB-Chain (Chain ID: 8721)

### DIFF
--- a/src/abi/multicall.ts
+++ b/src/abi/multicall.ts
@@ -407,6 +407,7 @@ function multicallAddress(chainId: number | BigInt) {
     case 1110: return '0x114575812CF34299cd65BD251C798608fa805433'; // grx
     case 1990: return '0xfD4014ba4dDB610A1587501378Fa52eee6C3a07B'; // qiev3
     case 38833: return '0x7B2Fa3e6CE90Ce6037395630a4C6DF45B7ef25Af'; // igra
+    case 8721: return '0x965b692662d431cc4714f4E6d1191b0B18733243'; // ebchain
     default:
       return null;
   }

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -204,6 +204,7 @@ const DEPLOYMENT_BLOCK = {
   injective: 1,
   occ: 1,
   pepu: 1,
+  ebchain: 1,
   citrea: 1,
   tempo: 1,
   edegex: 1,
@@ -354,5 +355,6 @@ const CUSTOM_MULTICALL_ADDRESSES: { [key: string]: string } = {
   'besc': '0xBcdb671cBC7711fE533E8B46E52EbC1470145F67',
   'capx': '0x8E1cd29c79dD1Dd4966Cd6A05EeC7d25B5f47f2b',
   'pepu': '0xBB6bf9447031408804af92aE6fBeDc002Dcb20aB',
+  'ebchain': '0x965b692662d431cc4714f4E6d1191b0B18733243',
   'citrea': '0xA738e84fdE890Bc60b99AF7ccE43990E534304de',
 }

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -204,7 +204,7 @@ const DEPLOYMENT_BLOCK = {
   injective: 1,
   occ: 1,
   pepu: 1,
-  ebchain: 1,
+  ebc: 1,
   citrea: 1,
   tempo: 1,
   edegex: 1,
@@ -355,6 +355,6 @@ const CUSTOM_MULTICALL_ADDRESSES: { [key: string]: string } = {
   'besc': '0xBcdb671cBC7711fE533E8B46E52EbC1470145F67',
   'capx': '0x8E1cd29c79dD1Dd4966Cd6A05EeC7d25B5f47f2b',
   'pepu': '0xBB6bf9447031408804af92aE6fBeDc002Dcb20aB',
-  'ebchain': '0x965b692662d431cc4714f4E6d1191b0B18733243',
+  'ebc': '0x965b692662d431cc4714f4E6d1191b0B18733243',
   'citrea': '0xA738e84fdE890Bc60b99AF7ccE43990E534304de',
 }

--- a/src/providers.json
+++ b/src/providers.json
@@ -3,6 +3,12 @@
     "rpc": [],
     "chainId": 1
   },
+  "ebchain": {
+    "rpc": [
+      "https://rpc.ebcscan.net"
+    ],
+    "chainId": 8721
+  },
   "bsc": {
     "rpc": [
       "https://bsc-dataseed.binance.org/"

--- a/src/providers.json
+++ b/src/providers.json
@@ -3,12 +3,6 @@
     "rpc": [],
     "chainId": 1
   },
-  "ebchain": {
-    "rpc": [
-      "https://rpc.ebcscan.net"
-    ],
-    "chainId": 8721
-  },
   "bsc": {
     "rpc": [
       "https://bsc-dataseed.binance.org/"


### PR DESCRIPTION
Adds EB-Chain (Chain ID: 8721), an EVM-compatible Proof of Authority blockchain.

- Added RPC in providers.json
- Added Multicall3 address in multicall3.ts and multicall.ts
- Multicall3 deployed at: 0x965b692662d431cc4714f4E6d1191b0B18733243
- RPC: https://rpc.ebcscan.net
- Explorer: https://ebcscan.net
- Website: https://eb-chain.com
- Listed on: chainlist.org, ethereum-lists/chains, DefiLlama
