### PR TITLE
Add LadyChain (chainId 589)

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -787,5 +787,11 @@
     ],
     "chainId": 123354377739506,
     "explorer": "https://stratoscan.strato.nexus/"
+  },
+  "ladychain": {
+    "rpc": [
+      "https://ladyrpc.us/rpc"
+    ],
+    "chainId": 589
   }
 }


### PR DESCRIPTION
## Add LadyChain

  Adds RPC configuration for **LadyChain**, a production EVM-compatible chain running Hyperledger Besu with QBFT consensus.

  - **Chain ID:** 589
  - **Chain key:** `ladychain`
  - **RPC:** https://ladyrpc.us/rpc
  - **Explorer:** https://ladyscan.us
  - **Listed in:** ethereum-lists/chains PR #8393

  This is required to support the LadySwap adapter in DefiLlama-Adapters.