### PR TITLE
Fix alternate ABI fallback success detection

### DIFF
--- a/src/abi/abi2.test.ts
+++ b/src/abi/abi2.test.ts
@@ -1,5 +1,6 @@
 import { call, multiCall, fetchList, } from "./abi2";
 import {  ChainApi } from "../ChainApi";
+import * as abi1 from "./index";
 
 const getReservesAbi = "function getReserves() view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)"
 
@@ -560,6 +561,50 @@ test("call with abis param and withMetadata", async () => {
   ).toEqual({
     output: "3914724000000000000",
   });
+});
+
+test("call with abis param returns first successful metadata result without trying later abis", async () => {
+  const spy = jest.spyOn(abi1, "call")
+    .mockResolvedValueOnce({ output: "expected-result" } as any)
+    .mockRejectedValueOnce(new Error("later abi should not run"))
+
+  try {
+    await expect(call({
+      target: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      params: "0x3FfBa143f5e69Aa671C9f8e3843C88742b1FA2D9",
+      abis: [
+        "erc20:balanceOf",
+        "function balanceOf_non_existant(address) view returns (uint256)",
+      ],
+      withMetadata: true,
+    })).resolves.toEqual({ output: "expected-result" })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  } finally {
+    spy.mockRestore()
+  }
+});
+
+test("call with abis param still falls through after an earlier failure", async () => {
+  const spy = jest.spyOn(abi1, "call")
+    .mockRejectedValueOnce(new Error("first abi failed"))
+    .mockResolvedValueOnce({ output: "fallback-result" } as any)
+
+  try {
+    await expect(call({
+      target: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      params: "0x3FfBa143f5e69Aa671C9f8e3843C88742b1FA2D9",
+      abis: [
+        "function balanceOf_non_existant(address) view returns (uint256)",
+        "erc20:balanceOf",
+      ],
+      withMetadata: true,
+    })).resolves.toEqual({ output: "fallback-result" })
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  } finally {
+    spy.mockRestore()
+  }
 });
 
 test("call with field param", async () => {

--- a/src/abi/abi2.ts
+++ b/src/abi/abi2.ts
@@ -26,7 +26,7 @@ export async function call(params: CallOptions): Promise<any> {
     for (let i = 0; i < abis.length - 1; i++) {
       const res = await call({ ...restParams, abi: abis[i], permitFailure: true, withMetadata: true })
       const response = params.withMetadata ? res : res.output
-      if (res.success) return response
+      if (res.success !== false) return response
     }
 
     const lastAbi = abis[abis.length - 1]


### PR DESCRIPTION
This fixes alternate ABI fallback for single-call `abis`.

Problem:
When `call()` is used with `abis`, earlier ABI attempts are executed with `permitFailure: true` and `withMetadata: true`.
Successful calls return `{ output: ... }`, while failures return `{ success: false, error: ... }`.

The fallback logic was checking `if (res.success)`, which meant a successful earlier ABI was not treated as success and execution could continue to a later ABI unnecessarily.

Fix:
- treat any result that is not an explicit failure as success
- add regression coverage for:
  - first ABI succeeds, later ABI must not run
  - first ABI fails, later ABI succeeds

Validation:
- `npm run build`
- `npm run test -- --runInBand src/abi/abi2.test.ts -t "call with abis param"`