### PR TITLE
Add 0G (0g) provider entry with archival RPCs

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -791,8 +791,7 @@
   "0g": {
     "rpc": [
       "https://0g.drpc.org",
-      "https://16661.rpc.thirdweb.com",
-      "https://evmrpc.0g.ai"
+      "https://16661.rpc.thirdweb.com"
     ],
     "chainId": 16661,
     "explorer": "https://chainscan.0g.ai"

--- a/src/providers.json
+++ b/src/providers.json
@@ -787,5 +787,14 @@
     ],
     "chainId": 123354377739506,
     "explorer": "https://stratoscan.strato.nexus/"
+  },
+  "0g": {
+    "rpc": [
+      "https://0g.drpc.org",
+      "https://16661.rpc.thirdweb.com",
+      "https://evmrpc.0g.ai"
+    ],
+    "chainId": 16661,
+    "explorer": "https://chainscan.0g.ai"
   }
 }


### PR DESCRIPTION
### Summary

Adds an explicit `0g` (0G Chain, chainId 16661) provider entry with **archival** RPCs.

### Why

The SDK currently has no `0g` entry, so it falls back to the community list's single RPC `https://evmrpc.0g.ai`, which is **not archival** — historical `eth_call` fails with `missing trie node ... state is not available`. This breaks any adapter that reads historical state on 0G (e.g. Uniswap-V3-style volume adapters whose pool-filtering does `balanceOf` at a past block).

Verified:
- `evmrpc.0g.ai` → non-archival (fails historical state)
- `https://0g.drpc.org` → archival ✅
- `https://16661.rpc.thirdweb.com` → archival ✅

### Change

Adds `0g` with archival endpoints first, keeping the official RPC as a fallback:

```json
"0g": {
  "rpc": [
    "https://0g.drpc.org",
    "https://16661.rpc.thirdweb.com",
    "https://evmrpc.0g.ai"
  ],
  "chainId": 16661,
  "explorer": "https://chainscan.0g.ai"
}
```

These are public archival endpoints; can be swapped for an official 0G archival RPC when available.
