### PR TITLE
multicall: accept mixed-case targets with invalid EIP-55 checksum, matching call()

### DIFF
--- a/src/abi/multicall3.test.ts
+++ b/src/abi/multicall3.test.ts
@@ -72,6 +72,26 @@ test("multicall invalid call", async () => {
   expect(output[1].success).toEqual(false);
 });
 
+test("multicall bad EIP-55 checksum target", async () => {
+  // single `call` accepts mixed-case targets without validating the checksum, multiCall should behave the same
+  const output = await makeMultiCall(decimalsAbi, [
+    { contract: '0xdAC17F958D2ee523a2206206994597C13D831Ec7', params: [] }, // invalid checksum (Ec7 instead of ec7)
+  ], 'ethereum')
+  expect(output[0].output).toEqual('6');
+  expect(output[0].success).toEqual(true);
+});
+
+test("multicall malformed target fails encoding", async () => {
+  const output = await makeMultiCall(decimalsAbi, [
+    { contract: '0xdac17f958d2ee523a2206206994597c13d831ec7', params: [] },
+    { contract: '0x1234', params: [] }, // not an address
+  ], 'ethereum')
+  expect(output[0].output).toEqual('6');
+  expect(output[0].success).toEqual(true);
+  expect(output[1].output).toEqual(null);
+  expect(output[1].success).toEqual(false);
+});
+
 test("set multicall via env", async () => {
   const testChain = 'env_multicall_chain'
   const fakeRPC = 'https://env_multicall_chain.org/'

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -246,15 +246,17 @@ export default async function makeMultiCall(
     try {
 
       const data = contractInterface.encodeFunctionData(fd, call.params)
-      if (call.contract?.startsWith('0x')) {
-        const _isValidAddress = ethers.getAddress(call.contract); // Validates and checksums the address
+      let contract = call.contract
+      if (contract?.startsWith('0x')) {
+        contract = contract.toLowerCase() // lowercase so a bad EIP-55 checksum does not reject the call - single `call` passes the target as-is to eth_call, so multiCall should accept the same input
+        const _isValidAddress = ethers.getAddress(contract); // Validates the address
       }
 
       goodCalls.push(call)
       goodEncodingIndexes.push(idx)
 
       return {
-        to: call.contract,
+        to: contract,
         data,
       }
     } catch (e) {


### PR DESCRIPTION
Fixes #217.

`api2.abi.call` passes the target through to eth_call as-is, so a mixed-case address with a wrong EIP-55 checksum works fine. `multiCall` however runs targets through `ethers.getAddress()`, which throws on bad checksums, so byte-identical input that works for a single read dies with an unhelpful "Bad encoding" / "Multicall failed!" when batched. Addresses copied from explorers or deploy manifests hit this regularly.

Fix: lowercase the target before validation in `makeMultiCall`, so validation still rejects malformed addresses but no longer enforces the checksum - same acceptance rules as `call`. The lowercased address is what goes into the multicall payload.

Repro (USDC with one flipped-case character in the target):
- before: `call` OK, `multiCall` throws `Multicall failed!`
- after: both return the same balance; valid-checksum and all-lowercase targets unchanged

Added two tests next to the existing "multicall invalid call" test: bad-checksum target succeeds, malformed target (`0x1234`) still fails per-call. Note the multicall3 suite has pre-existing failures in a bare local env (no RPC env vars) - identical failure set on master, the two new tests pass with a working ethereum RPC.