### PR TITLE
update multicall3 fallback

### DIFF
--- a/src/abi/multicall.ts
+++ b/src/abi/multicall.ts
@@ -408,8 +408,6 @@ function multicallAddress(chainId: number | BigInt) {
     case 1990: return '0xfD4014ba4dDB610A1587501378Fa52eee6C3a07B'; // qiev3
     case 38833: return '0x7B2Fa3e6CE90Ce6037395630a4C6DF45B7ef25Af'; // igra
     case 8721: return '0x965b692662d431cc4714f4E6d1191b0B18733243'; // ebchain
-    case 7119: return '0xFd4b34b5763f54a580a0d9f7997A2A993ef9ceE9'; // sentrix
-    case 36900: return '0x73df6E8F0D112D22bD672952323b43d6893AB6D2'; // adi
     default:
       return null;
   }

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -9,7 +9,7 @@ const MULTICALL_V3_ADDRESS = '0xca11bde05977b3631167028862be2a173976ca11'
 
 const TRY_AGGREGATE_ABI = 'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)'
 const AGGREGATE3_ABI = 'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)'
-
+const AGGREGATE3_ONLY_CHAINS = new Set<string>()
 const DEPLOYMENT_BLOCK = {
   ethereum: 14353601,
   ethf: 14353601,
@@ -285,13 +285,16 @@ export default async function makeMultiCall(
   }
 
   let returnValues: any
-  try {
-    // tryAggregate: (requireSuccess, [(target, callData)])
-    await _call(TRY_AGGREGATE_ABI, [false, contractCalls.map((call: any) => [call.to, call.data])])
-  } catch (e) {
-    // some Multicall3 deployments don't implement tryAggregate but do implement aggregate3
-    // aggregate3: ([(target, allowFailure, callData)])
-    await _call(AGGREGATE3_ABI, [contractCalls.map((call: any) => [call.to, true, call.data])])
+  const aggregate3Params = [contractCalls.map((call: any) => [call.to, true, call.data])]
+  if (AGGREGATE3_ONLY_CHAINS.has(chain)) {
+    await _call(AGGREGATE3_ABI, aggregate3Params)
+  } else {
+    try {
+      await _call(TRY_AGGREGATE_ABI, [false, contractCalls.map((call: any) => [call.to, call.data])])
+    } catch (e) {
+      await _call(AGGREGATE3_ABI, aggregate3Params)
+      AGGREGATE3_ONLY_CHAINS.add(chain)
+    }
   }
 
   return returnValues.map(([success, values]: any, index: number) => {

--- a/src/abi/multicall3.ts
+++ b/src/abi/multicall3.ts
@@ -7,6 +7,9 @@ import { call } from './index'
 // https://www.multicall3.com/deployments
 const MULTICALL_V3_ADDRESS = '0xca11bde05977b3631167028862be2a173976ca11'
 
+const TRY_AGGREGATE_ABI = 'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)'
+const AGGREGATE3_ABI = 'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)'
+
 const DEPLOYMENT_BLOCK = {
   ethereum: 14353601,
   ethf: 14353601,
@@ -216,6 +219,7 @@ const DEPLOYMENT_BLOCK = {
   srx: 1,
   xo: 1,
   rls: 1,
+  adi: 32217,
 } as {
   [key: string | Chain]: number
 }
@@ -282,10 +286,12 @@ export default async function makeMultiCall(
 
   let returnValues: any
   try {
-    await _call()
+    // tryAggregate: (requireSuccess, [(target, callData)])
+    await _call(TRY_AGGREGATE_ABI, [false, contractCalls.map((call: any) => [call.to, call.data])])
   } catch (e) {
-    // debugLog(chain, 'Multicall failed, retrying call...')
-    await _call()
+    // some Multicall3 deployments don't implement tryAggregate but do implement aggregate3
+    // aggregate3: ([(target, allowFailure, callData)])
+    await _call(AGGREGATE3_ABI, [contractCalls.map((call: any) => [call.to, true, call.data])])
   }
 
   return returnValues.map(([success, values]: any, index: number) => {
@@ -308,9 +314,9 @@ export default async function makeMultiCall(
     return res;
   });
 
-  async function _call() {
+  async function _call(abi: string, params: any[]) {
     const multicallAddress = getMulticallAddress(chain, block) as string
-    const { output: returnData } = await call({ chain, block, target: multicallAddress, abi: 'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)', params: [false, contractCalls.map((call: any) => [call.to, call.data])] })
+    const { output: returnData } = await call({ chain, block, target: multicallAddress, abi, params })
     returnValues = returnData;
   }
 }
@@ -366,4 +372,5 @@ const CUSTOM_MULTICALL_ADDRESSES: { [key: string]: string } = {
   'anubi': '0x2BaB36196519Ce9Cc31Bc4899FCBB8124A413b02',
   'srx': '0xFd4b34b5763f54a580a0d9f7997A2A993ef9ceE9',
   'xo': '0x7c6d6eAafF566E3B8a6D072ca1825E8F18141fDb',
+  'adi': '0x73df6E8F0D112D22bD672952323b43d6893AB6D2'
 }


### PR DESCRIPTION
Some multiCall3 contracts implement `aggregate3()` but not `tryAggregate()`. Instead of retrying `tryAggregate()` on errors, it uses the aggregate3 signature. Examples:
- sentrix: https://scan.sentrixchain.com/en/address/0xfd4b34b5763f54a580a0d9f7997a2a993ef9cee9
- adi: https://explorer-bls.adifoundation.ai/address/0x73df6E8F0D112D22bD672952323b43d6893AB6D2?tab=contract


Adi multiCall3 doesn't implement `aggregate` so multicall.js falls back to normal `call`, and sentrix was added into multiCall3 under `srx`