### PR TITLE
fix: getUSDValue concatenates string/bigint _usdBalances instead of summing

### DIFF
--- a/src/Balances.test.ts
+++ b/src/Balances.test.ts
@@ -629,3 +629,16 @@ test("Balances - debug", async () => {
   const { debugData: { tokenData } }: any = await balances.getUSDJSONs({ debug: true, debugOptions: { printTokenTable: false } })
   expect(tokenData.length).toBe(1)  // it should skip ethereum as it's less than 1% of total (10,000 USDT)
 })
+
+test("Balances - getUSDValue sums string _usdBalances numerically (not concat)", async () => {
+  const b = new Balances({})
+  b.addUSDValue('100', { id: 'FOO' })
+  b.addUSDValue('50', { id: 'BAR' })
+  expect(await b.getUSDValue()).toEqual(150)
+})
+
+test("Balances - getUSDValue with bigint _usdBalances input", async () => {
+  const b = new Balances({})
+  b.addUSDValue(BigInt(100), { id: 'FOO' })
+  expect(await b.getUSDValue()).toEqual(100)
+})

--- a/src/Balances.ts
+++ b/src/Balances.ts
@@ -235,7 +235,7 @@ export class Balances {
 
   async getUSDValue() {
     let { usdTvl } = await computeTVL(this.getBalances(), this.timestamp) as any
-    usdTvl = Object.values(this._usdBalances as any).reduce((a, b: any) => a + b, usdTvl as number)
+    usdTvl = Object.values(this._usdBalances as any).reduce((a: number, b: any) => a + Number(b), usdTvl as number)
     return usdTvl as number
   }
 


### PR DESCRIPTION
`Balances.getUSDValue()` reduces `_usdBalances` with no numeric conversion:

```js
usdTvl = Object.values(this._usdBalances as any).reduce((a, b: any) => a + b, usdTvl as number)
```

`_usdBalances` holds strings by design — `types.ts` types balances as `StringNumber | number`, and `sumSingleBalance` stringifies bigints (`balance.toString()`) before the non-number branch stores `Number(value).toString()`. So `number + string` concatenates instead of adding.

`getUSDJSONs()` in the same file already converts: `usdTvl += Number(balance)` — so the two USD accessors disagree.

Repro — both fail on master, pass with this change (no network; `_balances` is empty):

```js
const b = new Balances({})
b.addUSDValue('100', { id: 'FOO' })
b.addUSDValue('50',  { id: 'BAR' })
await b.getUSDValue()    // "010050"  — expected 150

const b2 = new Balances({})
b2.addUSDValue(BigInt(100), { id: 'FOO' })
await b2.getUSDValue()   // "0100"    — expected 100
```

`getUSDJSONs()` computes label/tag breakdowns via `breakdown.getUSDValue()`, so those inherit it too.

Fix: `Number(b)` in the reduce, mirroring `getUSDJSONs`. Existing tests all pass numbers so they're unaffected; added the two cases above.
