### PR TITLE
fix: blacklistedTokens/blacklistedOwners are ignored on tron

### DIFF
--- a/src/ChainApi.test.ts
+++ b/src/ChainApi.test.ts
@@ -668,3 +668,18 @@ test("ChainApi - getTokenBalances - non-existent token", async () => {
     ['0x0000000000000000000000000000000000000000', '1081418614616880']
   ])
 })
+
+test("ChainApi - blacklistedTokens excludes a base58 token on tron", async () => {
+  const api = new ChainApi({ chain: 'tron' })
+  const token = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t'  // USDT (tron, base58 case-sensitive)
+  const owner = 'TWd4WrZ9wn84f5x1hZhL4DHvk738ns5jwb'
+  // the only token/owner pair is blacklisted -> nothing left to query -> empty result, no RPC call.
+  // Before the fix, the blacklist was lowercased (chain not forwarded) while the pair kept base58
+  // casing, so it was never excluded and this would attempt a tron multicall instead.
+  const res = await api.getTokenBalances({
+    tokensAndOwners: [[token, owner]],
+    blacklistedTokens: [token],
+    withTokenData: true,
+  })
+  expect(res).toEqual([])
+})

--- a/src/ChainApi.ts
+++ b/src/ChainApi.ts
@@ -275,8 +275,8 @@ export class ChainApi {
 
     if (skipDuplicates)
       tokensAndOwners = getUniqueTokensAndOwners(tokensAndOwners, this.chain as string) as any
-    blacklistedOwners = getUniqueAddresses(blacklistedOwners)
-    blacklistedTokens = getUniqueAddresses(blacklistedTokens)
+    blacklistedOwners = getUniqueAddresses(blacklistedOwners, this.chain as string)
+    blacklistedTokens = getUniqueAddresses(blacklistedTokens, this.chain as string)
 
     tokensAndOwners = tokensAndOwners.filter(i => !blacklistedTokens.includes(i[0]) && !blacklistedOwners.includes(i[1]))
 


### PR DESCRIPTION
`ChainApi.getTokenBalances` normalizes the token/owner pairs **with** the chain but the blacklists **without** it:

```js
tokensAndOwners   = getUniqueTokensAndOwners(tokensAndOwners, this.chain)  // chain forwarded
blacklistedOwners = getUniqueAddresses(blacklistedOwners)                  // chain missing
blacklistedTokens = getUniqueAddresses(blacklistedTokens)                  // chain missing
tokensAndOwners = tokensAndOwners.filter(i => !blacklistedTokens.includes(i[0]) && !blacklistedOwners.includes(i[1]))
```

`getUniqueAddresses` only preserves case when `chain === 'tron'`. Without the chain arg the blacklist gets lowercased while the pairs keep base58 casing, so `includes()` never matches and the blacklist becomes a no-op — the tokens are counted anyway:

```js
getUniqueAddresses(["TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"])          // "tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t"  ← blacklist
getUniqueAddresses(["TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"], "tron")  // "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"  ← pairs
```

`sumTokens` always calls `getTokenBalances({ skipDuplicates: true })`, so the tron dedup-with-chain path is the live one.

Fix: forward `this.chain` to both `getUniqueAddresses` calls. Added a test asserting a base58 token in `blacklistedTokens` is excluded on tron.

Related, not fixed here to keep this scoped: on the `skipDuplicates: false` paths (`getERC20TokenBalances`, direct `getTokenBalances`) the pairs are never normalized, so a checksummed EVM address vs a lowercased blacklist mismatches the same way. Happy to follow up if you'd rather normalize both sides of the filter.
