### PR TITLE
abi: fix chunk-level multiCall failure crashing/misaligning results with permitFailure

### DIFF
--- a/src/abi/index.test.ts
+++ b/src/abi/index.test.ts
@@ -659,4 +659,73 @@ test("order is maintained in multicall", async () => {
   for (let i = 0; i < largeMulticall.calls.length; i++) {
     expect(result.output[i].input.target).toBe(largeMulticall.calls[i].target)
   }
+});
+
+describe("chunk-level failure in runInPromisePool", () => {
+  // Regression test for a bug where an entire chunk failing (as opposed to
+  // an individual call within it) caused runInPromisePool to return
+  // `undefined` for that chunk's slot. With permitFailure set, that
+  // undefined used to flow straight into flatResults and crash
+  // `.filter(r => !r.success)` with "Cannot read properties of undefined
+  // (reading 'success')" - and even without the crash, collapsing a whole
+  // chunk's many calls into one slot would have silently shortened and
+  // misaligned the output array against the original calls.
+  test("permitFailure reconstructs a failed chunk instead of crashing or misaligning results", async () => {
+    jest.resetModules()
+    jest.doMock('../util', () => {
+      const actual = jest.requireActual('../util')
+      return {
+        ...actual,
+        runInPromisePool: jest.fn(async (params: any) => {
+          // Simulate chunk 1 (of 3) throwing entirely, as a chunk-level RPC
+          // failure would - runInPromisePool's own real catch block returns
+          // undefined for a failed chunk's slot; we replicate that directly
+          // here rather than re-testing runInPromisePool's own catch logic.
+          return params.items.map((chunk: any, i: number) =>
+            i === 1 ? undefined : chunk.map((call: any) => ({
+              input: { target: call.contract, params: call.params },
+              success: true,
+              output: "1",
+            }))
+          )
+        }),
+      }
+    })
+    const { multiCall: multiCallWithMockedPool } = require('./index')
+
+    const calls = [0, 1, 2, 3, 4, 5].map(i => ({
+      target: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      params: [i],
+    }))
+
+    const res = await multiCallWithMockedPool({
+      calls,
+      abi: "erc20:balanceOf",
+      chunkSize: 2,
+      permitFailure: true,
+    })
+
+    // Length and order must be preserved even though a whole chunk failed -
+    // this is the part a naive crash-avoidance fix (e.g. just filtering out
+    // undefined entries) would still get wrong.
+    expect(res.output.length).toBe(6)
+    res.output.forEach((r: any, i: number) => {
+      expect(r.input.params).toEqual([i])
+    })
+
+    // Chunk 1 (calls at index 2 and 3, given chunkSize 2) is the one our
+    // mock made fail entirely.
+    expect(res.output[2].success).toBe(false)
+    expect(res.output[2].output).toBe(null)
+    expect(res.output[3].success).toBe(false)
+    expect(res.output[3].output).toBe(null)
+
+    // The other two chunks succeeded and should be untouched.
+    expect(res.output[0].success).toBe(true)
+    expect(res.output[1].success).toBe(true)
+    expect(res.output[4].success).toBe(true)
+    expect(res.output[5].success).toBe(true)
+
+    jest.dontMock('../util')
+  })
 })

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -231,14 +231,35 @@ export async function multiCall(params: MulticallOptions): Promise<any> {
   if (!params.skipCache) return cachedMultiCall(params)
 
   const abi = resolveABI(params.abi);
+  const chunkedCalls = sliceIntoChunks(contractCalls, chunkSize)
   const results = await runInPromisePool({
-    items: sliceIntoChunks(contractCalls, chunkSize),
+    items: chunkedCalls,
     concurrency: 10,
     processor: (calls: any) => makeMultiCall(abi, calls, chain as Chain, params.block),
     permitFailure: params.permitFailure,
   })
 
-  const flatResults = [].concat.apply([], results) as any[]
+  // When an entire chunk's processor call throws (e.g. a chunk-level RPC
+  // failure, as opposed to an individual call within it), runInPromisePool
+  // returns `undefined` for that chunk's slot instead of the expected array
+  // of one result per call. If permitFailure is set, that undefined flows
+  // straight through here uncaught, and both the .filter(r => !r.success)
+  // below and the flatResults[i].output access further down crash on it -
+  // and even without the crash, replacing a whole chunk's many calls with a
+  // single slot silently shortens and misaligns the array against
+  // contractCalls. Reconstruct a properly-shaped failure entry per call in
+  // any failed chunk instead, matching what makeMultiCall itself returns on
+  // an individual call failure, so length/order stay correct either way.
+  const resultsWithFailedChunksExpanded = results.map((chunkResult: any, i: number) => {
+    if (chunkResult !== undefined) return chunkResult
+    return chunkedCalls[i].map((call: any) => ({
+      input: { params: call.params, target: call.contract },
+      success: false,
+      output: null,
+    }))
+  })
+
+  const flatResults = [].concat.apply([], resultsWithFailedChunksExpanded) as any[]
 
   const failedQueries = flatResults.filter(r => !r.success)
   if (failedQueries.length) {


### PR DESCRIPTION
When a whole chunk's processor call throws inside runInPromisePool
(e.g. a chunk-level RPC failure, as opposed to an individual call
within it), it returns undefined for that chunk's slot instead of the
expected array of one result per call. With permitFailure set, that
undefined flows straight through into abi/index.ts's flatResults,
where flatResults.filter(r => !r.success) crashes with "Cannot read
properties of undefined (reading 'success')".

Even without the crash, collapsing a whole chunk's many calls into a
single undefined slot would silently shorten and misalign the results
array against the original contractCalls, since flatResults[i].output
is used later assuming a strict one-to-one correspondence.

Found this via a real, reproducible CI failure on an unrelated PR
(DefiLlama/dimension-adapters#8231) - a brand-new registry entry with
correctly-shaped config that ran clean for 14/24 hourly slots in CI
before crashing at slot 15 with this exact error, at this exact SDK
version and line. Confirmed via the actual job logs that it wasn't
anything specific to that PR's config - a transient chunk-level
failure during that one specific hour of on-chain data, not a config
or logic problem.

Fix: when a chunk's result is undefined, reconstruct a properly-shaped
{ success: false, output: null, input } entry for each call that was
in that chunk, using the same chunked-calls array already computed for
runInPromisePool's input, rather than letting the bare undefined
propagate through.

Added a regression test that mocks runInPromisePool to simulate one
chunk (of three) failing entirely, and verifies: no crash, the output
array length matches the original call count exactly, the failed
chunk's calls come back as properly-shaped success:false entries in
the right positions, and the other two chunks' real results are
unaffected.

Verified locally: TEST_MODE=true npx jest src/abi/index.test.ts runs
clean - 21 passed (1 new), 0 failed. One test ("maker call doesn't do
weird things") failed on the very first full run but passed on two
immediate re-runs with no code change in between; it's a plain single
call() with no chunking involved at all, so this is a pre-existing,
transient RPC flake unrelated to this change, not a regression.