### PR TITLE
test(tron): document delegated Stake 2.0 balance semantics

### DIFF
--- a/src/abi/tron.test.ts
+++ b/src/abi/tron.test.ts
@@ -3,6 +3,7 @@ import { getBalance, getBalances } from "../eth/index";
 import { ETHER_ADDRESS } from "../general";
 import { getLatestBlock, lookupBlock } from "../util/blocks";
 import getLogs from "../util/logs";
+import { getAccountBalanceFromResponse } from "./tron";
 
 
 const intercroneFactory = 'TPvaMEL5oY2gWsJv7MDjNQh2dohwvwwVwx'
@@ -110,6 +111,27 @@ test("tron: getBalance", async () => {
       target: intercroneFactory,
     })
   ).toEqual({ "output": "0" });
+});
+
+test("tron: getBalance includes delegated-out Stake 2.0 without double-counting", () => {
+  // Captured from wallet/getaccount for 4162d355... at block 84,790,123,
+  // immediately after it delegated resources in block 84,790,105.
+  // The two frozenV2 buckets plus their delegated-out counterparts reconstruct
+  // exactly 200,000,000 TRX staked by the account.
+  const account = {
+    balance: 177_051_168,
+    frozenV2: [
+      { amount: 9_820_151_335_298 },
+      { type: "ENERGY", amount: 126_635_099_000_000 },
+      { type: "TRON_POWER" },
+    ],
+    delegated_frozenV2_balance_for_bandwidth: 179_848_664_702,
+    account_resource: {
+      delegated_frozenV2_balance_for_energy: 63_364_901_000_000,
+    },
+  };
+
+  expect(getAccountBalanceFromResponse(account)).toEqual("200000177051168");
 });
 
 test("tron: getBalances", async () => {

--- a/src/abi/tron.ts
+++ b/src/abi/tron.ts
@@ -48,16 +48,23 @@ export async function getBalance(params: {
     return balanceCache[params.target]
   })
 
-  const frozenBalance = data.frozen?.reduce((t: any, { frozen_balance }: any) => t + frozen_balance, 0) ?? 0
-  const frozenBalanceV2 = data.frozenV2?.reduce((t: any, { amount = 0 }: any) => t + amount, 0) ?? 0
-  const freeBalance = data.balance ?? 0
-  const delegatedBandwidthBalance = data.delegated_frozenV2_balance_for_bandwidth ?? 0
-  const delegatedEnergyBalance = data.account_resource?.delegated_frozenV2_balance_for_energy ?? 0
-  let balance = (freeBalance + frozenBalance + frozenBalanceV2 + delegatedBandwidthBalance + delegatedEnergyBalance).toString()
+  const balance = getAccountBalanceFromResponse(data)
 
   return {
     output: handleDecimals(balance, params.decimals),
   };
+}
+
+export function getAccountBalanceFromResponse(data: any): string {
+  const frozenBalance = data.frozen?.reduce((t: any, { frozen_balance }: any) => t + frozen_balance, 0) ?? 0
+  const frozenBalanceV2 = data.frozenV2?.reduce((t: any, { amount = 0 }: any) => t + amount, 0) ?? 0
+  const freeBalance = data.balance ?? 0
+  // Delegated-out Stake 2.0 amounts are removed from frozenV2 and reported
+  // separately on the delegator account. Include them to reconstruct all TRX
+  // still owned by the account; see the live-account fixture in tron.test.ts.
+  const delegatedBandwidthBalance = data.delegated_frozenV2_balance_for_bandwidth ?? 0
+  const delegatedEnergyBalance = data.account_resource?.delegated_frozenV2_balance_for_energy ?? 0
+  return (freeBalance + frozenBalance + frozenBalanceV2 + delegatedBandwidthBalance + delegatedEnergyBalance).toString()
 }
 
 export async function getBalances(params: {


### PR DESCRIPTION
## Summary

- extract TRON account-balance reconstruction into a deterministic helper
- document why delegated-out Stake 2.0 fields must be added to `frozenV2`
- add a regression fixture captured from a live delegator account

Resolves #238 with empirical mainnet evidence: the current formula is correct, and removing the delegated fields would undercount account-owned TRX.

## Mainnet receipt

Account [`TJykPcjCtdYLAJLUgGTUF5gYEcxpbz58Qc`](https://tronscan.org/#/address/TJykPcjCtdYLAJLUgGTUF5gYEcxpbz58Qc) (`4162d355...`) delegated resources in block `84,790,105`. A `wallet/getaccount` snapshot at block `84,790,123` returned:

- free balance: `177,051,168` sun
- bandwidth `frozenV2`: `9,820,151,335,298` sun
- delegated bandwidth: `179,848,664,702` sun
- energy `frozenV2`: `126,635,099,000,000` sun
- delegated energy: `63,364,901,000,000` sun

The buckets close exactly:

- bandwidth: `9,820,151,335,298 + 179,848,664,702 = 10,000,000,000,000`
- energy: `126,635,099,000,000 + 63,364,901,000,000 = 190,000,000,000,000`
- total Stake 2.0: `200,000,000,000,000` sun = `200,000,000 TRX`

So the delegated-out amounts are not subsets still present in `frozenV2`; they are the exact portions moved out of those buckets. Adding them reconstructs the delegator's owned stake. Omitting them would report only `136,455,250.335298 TRX` of the `200,000,000 TRX` stake.

## Tests

- `pnpm run build`
- `pnpm exec jest src/abi/tron.test.ts --runInBand --testNamePattern='delegated-out Stake 2.0'` — passed

The full live TRON test file was also attempted: the deterministic test and 12 network tests passed; four public-RPC-dependent tests hit TronGrid's unauthenticated 3-RPS `429` limit.