### PR TITLE
Fix stale current prices: 30-min cache refresh never ran

### DIFF
--- a/src/util/coins.test.ts
+++ b/src/util/coins.test.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { getPrices, getMcaps } from "./coins";
 
 test("coinsApi - mcaps", async () => {
@@ -17,6 +18,22 @@ test("coinsApi - prices", async () => {
     expect(res2["ethereum:0xdac17f958d2ee523a2206206994597c13d831ec7"].decimals).toBe(6);
     expect(Object.keys(res).length).toBe(3);
     expect(res["solana:So11111111111111111111111111111111111111112"].timestamp).toBeGreaterThan(Math.floor(Date.now() / 1e3 - 3600));
+})
+
+test("coinsApi - current prices are refetched after cache TTL", async () => {
+    const realNow = Date.now;
+    const postSpy = jest.spyOn(axios, "post");
+    try {
+        await getPrices(["coingecko:ethereum"], "now");
+        const callsAfterFirst = postSpy.mock.calls.length;
+        Date.now = () => realNow() + 31 * 60 * 1000; // move past the 30-minute "now" cache TTL
+        const res = await getPrices(["coingecko:ethereum"], "now");
+        expect(postSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst); // expired cache must trigger a live refetch
+        expect(res["coingecko:ethereum"].price).toBeGreaterThan(0);
+    } finally {
+        Date.now = realNow;
+        postSpy.mockRestore();
+    }
 })
 
 test("coinsApi - prices with timestamp", async () => {

--- a/src/util/coins.ts
+++ b/src/util/coins.ts
@@ -71,14 +71,21 @@ async function fetchWithProFallback(body: any, subRoute: string) {
   }));
 }
 
-const priceCacheAll: { [timestamp: string]: { [PK: string]: any } } = {
-  now: {
+const nowCacheTTL = 1000 * 60 * 30 // 30 minutes, matches priceUpdateTime in computeTVL
+let lastNowCacheClear = +Date.now();
+
+function seedNowPriceCache() {
+  return {
     "coingecko:tether": {
       price: 1,
       symbol: "USDT",
       timestamp: Math.floor(Date.now() / 1e3 + 3600), // an hour from script start time
     },
-  }
+  };
+}
+
+const priceCacheAll: { [timestamp: string]: { [PK: string]: any } } = {
+  now: seedNowPriceCache()
 };
 
 const mcapCacheAll: { [timestamp: string]: { [PK: string]: any } } = {};
@@ -93,6 +100,14 @@ async function getPricesData(
   dataType: "price" | "mcap"
 ): Promise<any> {
   if (!readKeys.length) return {};
+
+  // expire the "now" caches so current prices are never served older than nowCacheTTL
+  if (+Date.now() - lastNowCacheClear > nowCacheTTL) {
+    lastNowCacheClear = +Date.now();
+    priceCacheAll.now = seedNowPriceCache();
+    delete mcapCacheAll.now;
+  }
+
   const cacheAllObject = dataType === "price" ? priceCacheAll : mcapCacheAll
   const subRoute = dataType === "price" ? "prices" : "mcaps"
 

--- a/src/util/computeTVL.test.ts
+++ b/src/util/computeTVL.test.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import computeTVL from './computeTVL';
 
 test("computeTVL - tether bal", async () => {
@@ -27,6 +28,22 @@ test("computeTVL - usdTokenBalances", async () => {
   expect(usdTokenBalances.SOL).toBeGreaterThan(3000);
   expect(usdTokenBalances.USDT).toBeGreaterThan(999);
   expect(usdTokenBalances.ETH).toBeUndefined();
+})
+
+test("computeTVL - current prices refresh after cache TTL", async () => {
+  const realNow = Date.now;
+  const postSpy = jest.spyOn(axios, "post");
+  try {
+    await computeTVL({ 'ethereum': 5 });
+    const callsAfterFirst = postSpy.mock.calls.length;
+    Date.now = () => realNow() + 31 * 60 * 1000; // move past the 30-minute price cache TTL
+    const { usdTvl } = await computeTVL({ 'ethereum': 5 });
+    expect(postSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst); // stale cache must be cleared and refetched live
+    expect(usdTvl).toBeGreaterThan(3000);
+  } finally {
+    Date.now = realNow;
+    postSpy.mockRestore();
+  }
 })
 
 test("computeTVL - past Ethereum balance", async () => {

--- a/src/util/computeTVL.ts
+++ b/src/util/computeTVL.ts
@@ -13,7 +13,7 @@ const priceCaches: {
   [timestamp: number]: PricesObject
 } = {}
 
-let lastPriceUpdate = 0;
+let lastPriceUpdate = +Date.now();
 const confidenceThreshold = 0.5
 const priceUpdateTime = 1000 * 60 * 30 // 30 minutes
 


### PR DESCRIPTION
## Bug

In `computeTVL.ts` the periodic cache clear is dead code — `lastPriceUpdate` starts at 0 and is only ever set inside a branch it gates:

```ts
let lastPriceUpdate = 0;
if (!timestamp && lastPriceUpdate && +Date.now() > lastPriceUpdate + priceUpdateTime) {
    lastPriceUpdate = +Date.now()
```

And `coins.ts` caches current prices under `priceCacheAll["now"]` with no expiry, so even a cleared outer cache gets refilled with process-start prices. Any process alive >30 min converts balances to USD at prices frozen at first fetch.

## Fix

- `computeTVL.ts`: initialize `lastPriceUpdate` to `Date.now()` so the clear branch is reachable
- `coins.ts`: 30-min TTL in `getPricesData` that reseeds the `now` price cache and drops the `now` mcap cache

Historical (timestamped) caches unchanged.

## Tests

Added TTL tests in `coins.test.ts` and `computeTVL.test.ts` (live API + `jest.spyOn`, same pattern as existing chainUtils tests). Both fail on master, pass here.
