### PR TITLE
balances: pad starknet addresses missing more than one leading zero

### DIFF
--- a/src/Balances.test.ts
+++ b/src/Balances.test.ts
@@ -642,3 +642,36 @@ test("Balances - getUSDValue with bigint _usdBalances input", async () => {
   b.addUSDValue(BigInt(100), { id: 'FOO' })
   expect(await b.getUSDValue()).toEqual(100)
 })
+
+test("Balances - starknet address is padded to the canonical 32 byte form", async () => {
+  const STRK = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
+  const DAI = '0x00da114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3'
+
+  // what BigInt(addr).toString(16) leaves behind, one and two leading zeros dropped
+  const strkStripped = '0x' + STRK.slice(2).replace(/^0+/, '')
+  const daiStripped = '0x' + DAI.slice(2).replace(/^0+/, '')
+  expect(strkStripped.length).toBe(65)
+  expect(daiStripped.length).toBe(64)
+
+  const balances = new Balances({ chain: 'starknet' })
+  balances.add(strkStripped, 100)
+  balances.add(daiStripped, 200)
+  balances.add(STRK, 1)
+
+  expect(balances.getBalances()).toEqual({
+    [`starknet:${STRK}`]: 101,
+    [`starknet:${DAI}`]: 200,
+  })
+})
+
+test("Balances - starknet padding leaves other chains and skipChain alone", async () => {
+  const short = '0x4c46e830bb56ce22735d5d8fc9cb90309317d0f'
+
+  const evm = new Balances({ chain: 'ethereum' })
+  evm.add(short, 100)
+  expect(evm.getBalances()).toEqual({ 'ethereum:0x4c46e830bb56ce22735d5d8fc9cb90309317d0f': 100 })
+
+  const cg = new Balances({ chain: 'starknet' })
+  cg.addCGToken('ethereum', 5)
+  expect(cg.getBalances()).toEqual({ 'coingecko:ethereum': 5 })
+})

--- a/src/Balances.ts
+++ b/src/Balances.ts
@@ -85,9 +85,9 @@ export class Balances {
       token = token.replace('peggy', '')
     }
 
-    // add a leading 0 to the token if it's a starknet token
-    if (!skipChain && this.chain === 'starknet' && token.length === 65) {
-      token = token.replace('0x', '0x0')
+    // pad starknet token addresses back to the canonical 32 byte form
+    if (!skipChain && this.chain === 'starknet' && token.startsWith('0x') && token.length < 66) {
+      token = '0x' + token.slice(2).padStart(64, '0')
     }
 
     if (isUSDValue) {


### PR DESCRIPTION
`_add()` normalises starknet token addresses back to the canonical 32 byte form, but only in the case where exactly one leading zero nibble is missing:

```ts
// add a leading 0 to the token if it's a starknet token
if (!skipChain && this.chain === 'starknet' && token.length === 65) {
  token = token.replace('0x', '0x0')
}
```

starknet felts are below 2^251, so canonical addresses with leading zero bytes are common, and anything that derives an address arithmetically rather than copying the literal drops all of the leading zeros rather than one. `0x${value.toString(16)}` is the usual shape — `projects/helper/curators/index.js` builds vToken and asset addresses that way for vesu, and it is a shared helper so several curator protocols go through it.

Only the one-nibble case is repaired:

```
missing 1 nibble  -> len 65 -> normalised to 66
missing 2 nibbles -> len 64 -> left at 64
missing 3 nibbles -> len 63 -> left at 63
```

Two missing nibbles is not a corner case. Of the 22 starknet entries in `helpers/coreAssets.json` in dimension-adapters, 18 have a single leading zero and are repaired today, and 4 have two and are not:

| symbol | address |
|---|---|
| DAI | `0x00da114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3` |
| WSTETH_1 | `0x0057912720381af14b0e5c87aa4718ed5e527eab60b3801ebf702ab09139e38b` |
| ZEND | `0x00585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34` |
| NSTR | `0x00c530f2c0aa4c16a0806365b0898499fba372e5df7a7172dc6fe9ba777e8007` |

So an adapter that adds one of those four from a literal and again from a derived value ends up with the same token under two different keys in one `Balances`, and `getBalances()` reports it twice.

This replaces the length check with a pad to 64 hex characters, which covers any number of missing leading zeros and leaves already-canonical addresses untouched.

Being explicit about what this does not fix, since the obvious guess is wrong: USD totals are not affected. `coins.llama.fi` normalises starknet addresses on its side as well, and both forms return the same price, so a split key still sums to the right dollar value. The change is about `Balances` keeping its own keys consistent, not about correcting a published number.

One behaviour change worth flagging. `removeTokenBalance` matches with `new RegExp(token, 'i')` against the stored keys, so it is a substring match. With this change adds are always stored padded, and an adapter that removes using an unpadded literal would no longer match, where before it would have matched an equally unpadded stored key. Anything that adds and removes using the same literal is unaffected either way.

Tests cover the two-nibble case with the real STRK and DAI addresses, that adding the padded and unpadded forms of one token accumulates into a single key, and that ethereum addresses and `skipChain` callers are left alone. The first test fails on master, splitting DAI across `starknet:0xda1142...` and `starknet:0x00da1142...`.
