### PR TITLE
humanizenumber: switch unit at the threshold, not one above it

### DIFF
--- a/src/computeTVL/humanizeNumber.test.ts
+++ b/src/computeTVL/humanizeNumber.test.ts
@@ -21,4 +21,17 @@ describe('humanizeNumber', () => {
     expect(humanizeNumber(141.00034)).toBe('141.00')
     expect(humanizeNumber(-1)).toBe('-1.00')
   })
+
+  it('should switch unit exactly at each threshold', () => {
+    expect(humanizeNumber(1000)).toBe('1.00 k')
+    expect(humanizeNumber(10 ** 6)).toBe('1.00 M')
+    expect(humanizeNumber(10 ** 9)).toBe('1.00 B')
+    expect(humanizeNumber(10 ** 12)).toBe('1.00 T')
+    expect(humanizeNumber(-1000)).toBe('-1.00 k')
+    expect(humanizeNumber(-(10 ** 6))).toBe('-1.00 M')
+    expect(humanizeNumber(-(10 ** 9))).toBe('-1.00 B')
+    expect(humanizeNumber(-(10 ** 12))).toBe('-1.00 T')
+    expect(humanizeNumber(999.99)).toBe('999.99')
+    expect(humanizeNumber(10 ** 6 - 1)).toBe('1000.00 k')
+  })
 })

--- a/src/computeTVL/humanizeNumber.ts
+++ b/src/computeTVL/humanizeNumber.ts
@@ -8,7 +8,7 @@ export function humanizeNumber(amount: number): string {
     [10 ** 3, "k"],
   ] as [number, string][];
   for (const [denominator, letter] of quantifiers) {
-    if (amount > denominator) {
+    if (amount >= denominator) {
       return `${(amount / denominator).toFixed(2)} ${letter}`;
     }
   }


### PR DESCRIPTION
`humanizeNumber` picks its unit with a strict `>`, so a value sitting exactly on a threshold falls through to the next check down and is rendered in the wrong unit:

```ts
for (const [denominator, letter] of quantifiers) {
  if (amount > denominator) {
    return `${(amount / denominator).toFixed(2)} ${letter}`;
  }
}
```

Every exact power of a thousand is affected, in both signs:

```
1000            -> "1000.00"       expected "1.00 k"
10 ** 6         -> "1000.00 k"     expected "1.00 M"
10 ** 9         -> "1000.00 M"     expected "1.00 B"
10 ** 12        -> "1000.00 B"     expected "1.00 T"
-1000           -> "-1000.00"      expected "-1.00 k"
```

`1000` is the only one that loses its unit entirely, since `k` is the last quantifier and there is nothing below it to fall through to. The rest degrade to the unit below, which reads as a 1000x error at a glance in the token tables `Balances.getUSDJSONs` prints under `debug`.

Changing the comparison to `>=` fixes all of them and leaves everything else alone. Values just under a threshold keep their current rendering, so `10 ** 6 - 1` is still `"1000.00 k"` and `999.99` is still `"999.99"`.

The existing test only used values comfortably inside each band, which is why this stayed hidden. The added case pins both directions at each of the four thresholds and keeps the just-below values, and it fails on master with `Expected "1.00 k", Received "1000.00"`.

`humanizeNumber` is re-exported from the package root, so this is user visible beyond the internal debug output.
