### PR TITLE
getLogs: keep cached logs when trimming instead of persisting an empty range

### DIFF
--- a/src/util/logs.test.ts
+++ b/src/util/logs.test.ts
@@ -1,5 +1,5 @@
 import ChainApi from "../ChainApi";
-import { getLogs, toFilterTopic, trimCachesForStorage, } from "./logs";
+import { getLogs, maxLogsForStorage, toFilterTopic, trimCachesForStorage, } from "./logs";
 
 const baseApi = new ChainApi({ chain: 'base' })
 
@@ -373,4 +373,30 @@ test("trimCachesForStorage - keeps only the newest range when several are cached
   expect(out).toHaveLength(1)
   expect(out[0].metadata.fromBlock).toBe(900)
   expect(out[0].logs).toHaveLength(3)
+})
+
+test("maxLogsForStorage - a wide log caps below the flat 200k", () => {
+  // seaport OrderFulfilled sampled around 2192 bytes of JSON per log
+  expect(maxLogsForStorage(2192)).toBe(Math.floor((300 * 1024 * 1024) / 2192))
+  expect(maxLogsForStorage(2192)).toBeLessThan(200_000)
+  expect(maxLogsForStorage(2192) * 2192).toBeLessThanOrEqual(300 * 1024 * 1024)
+})
+
+test("maxLogsForStorage - a narrow log keeps the flat 200k cap", () => {
+  expect(maxLogsForStorage(200)).toBe(200_000)
+  expect(maxLogsForStorage(1572)).toBe(200_000)
+  expect(maxLogsForStorage(1573)).toBeLessThan(200_000)
+})
+
+test("maxLogsForStorage - a missing or absurd length falls back to the cap", () => {
+  expect(maxLogsForStorage(0)).toBe(200_000)
+  expect(maxLogsForStorage(undefined as any)).toBe(200_000)
+  expect(maxLogsForStorage(400 * 1024 * 1024)).toBe(1)
+})
+
+test("trimCachesForStorage - honours a byte derived cap", () => {
+  const caches = [{ logs: mkLogs(10, 1000), metadata: { fromBlock: 1000, toBlock: 1009 } }] as any
+  const out = trimCachesForStorage(caches, maxLogsForStorage(60 * 1024 * 1024))
+  expect(out[0].logs).toHaveLength(5)
+  expect(out[0].metadata.fromBlock).toBe(1005)
 })

--- a/src/util/logs.test.ts
+++ b/src/util/logs.test.ts
@@ -1,5 +1,5 @@
 import ChainApi from "../ChainApi";
-import { getLogs, toFilterTopic, } from "./logs";
+import { getLogs, toFilterTopic, trimCachesForStorage, } from "./logs";
 
 const baseApi = new ChainApi({ chain: 'base' })
 
@@ -333,3 +333,44 @@ test("logs - onlyArgs are iterable arrays with named fields", async () => {
 
   expect(totalAmount1In).toBe(BigInt(1000));
 });
+
+const mkLogs = (count: number, startBlock: number) =>
+  Array.from({ length: count }, (_, i) => ({ blockNumber: startBlock + i, transactionHash: '0x' + i, index: i })) as any[]
+
+test("trimCachesForStorage - keeps logs when the range is under the cap", () => {
+  const caches = [{ logs: mkLogs(10, 100), metadata: { fromBlock: 100, toBlock: 109 } }] as any
+  const out = trimCachesForStorage(caches, 200_000)
+  expect(out).toHaveLength(1)
+  expect(out[0].logs).toHaveLength(10)
+  expect(out[0].metadata).toEqual({ fromBlock: 100, toBlock: 109 })
+})
+
+test("trimCachesForStorage - never reports a range it has no logs for", () => {
+  const caches = [{ logs: mkLogs(5, 500), metadata: { fromBlock: 500, toBlock: 504 } }] as any
+  const out = trimCachesForStorage(caches, 200_000)
+  for (const c of out) {
+    if (!c.logs.length) continue
+    expect(c.metadata.fromBlock).toBeLessThanOrEqual(c.logs[c.logs.length - 1].blockNumber)
+  }
+  expect(out[0].logs.length).toBeGreaterThan(0)
+})
+
+test("trimCachesForStorage - trims to the cap and narrows fromBlock to what survived", () => {
+  const caches = [{ logs: mkLogs(10, 1000), metadata: { fromBlock: 1000, toBlock: 1009 } }] as any
+  const out = trimCachesForStorage(caches, 4)
+  expect(out[0].logs).toHaveLength(4)
+  expect(out[0].logs.map((l: any) => l.blockNumber)).toEqual([1009, 1008, 1007, 1006])
+  expect(out[0].metadata.fromBlock).toBe(1006)
+  expect(out[0].metadata.toBlock).toBe(1009)
+})
+
+test("trimCachesForStorage - keeps only the newest range when several are cached", () => {
+  const caches = [
+    { logs: mkLogs(3, 100), metadata: { fromBlock: 100, toBlock: 102 } },
+    { logs: mkLogs(3, 900), metadata: { fromBlock: 900, toBlock: 902 } },
+  ] as any
+  const out = trimCachesForStorage(caches, 200_000)
+  expect(out).toHaveLength(1)
+  expect(out[0].metadata.fromBlock).toBe(900)
+  expect(out[0].logs).toHaveLength(3)
+})

--- a/src/util/logs.ts
+++ b/src/util/logs.ts
@@ -252,8 +252,9 @@ export async function getLogs(
       }, 0);
       const fileSizeInMB = (totalLogCount * randomLogLength) / (1024 * 1024)
       if (fileSizeInMB > 300) { // if cache size is larger than ~300MB, trim it down
-        console.log(`getLogs: large cache size detected ${totalLogCount} logs size: ${fileSizeInMB}MB, retaining only the latest 200k logs to limit memory usage target=${target} topic=${topic} fromBlock=${fromBlock} toBlock=${toBlock}`);
-        storeCaches = trimCachesForStorage(storeCaches)
+        const maxLogs = maxLogsForStorage(randomLogLength)
+        console.log(`getLogs: large cache size detected ${totalLogCount} logs size: ${fileSizeInMB}MB, retaining only the latest ${maxLogs} logs to limit memory usage target=${target} topic=${topic} fromBlock=${fromBlock} toBlock=${toBlock}`);
+        storeCaches = trimCachesForStorage(storeCaches, maxLogs)
       }
 
       // we are skipping compression by default, so reads & writes are faster
@@ -314,6 +315,12 @@ export async function getLogs(
 /* -------------------------------------------------------------------------- */
 /*                           Utility helpers exported                         */
 /* -------------------------------------------------------------------------- */
+
+// the log count that fits the same byte budget the size check uses, so a wide log trims before the flat cap
+export function maxLogsForStorage(bytesPerLog: number, cap = 200_000, budgetMB = 300): number {
+  if (!bytesPerLog || bytesPerLog < 1) return cap
+  return Math.max(1, Math.min(cap, Math.floor((budgetMB * 1024 * 1024) / bytesPerLog)))
+}
 
 // keeps the newest range and at most maxLogs of its logs, narrowing the metadata to match what is kept
 export function trimCachesForStorage(caches: logCache[], maxLogs = 200_000): logCache[] {

--- a/src/util/logs.ts
+++ b/src/util/logs.ts
@@ -253,30 +253,7 @@ export async function getLogs(
       const fileSizeInMB = (totalLogCount * randomLogLength) / (1024 * 1024)
       if (fileSizeInMB > 300) { // if cache size is larger than ~300MB, trim it down
         console.log(`getLogs: large cache size detected ${totalLogCount} logs size: ${fileSizeInMB}MB, retaining only the latest 200k logs to limit memory usage target=${target} topic=${topic} fromBlock=${fromBlock} toBlock=${toBlock}`);
-
-        // retain only the latest logs that fit within 300,000 logs
-        if (caches.length > 1) {
-          let cacheWithLatestFromBlock = caches[0]
-          for (const c of caches) {
-            if (c.metadata.fromBlock > cacheWithLatestFromBlock.metadata.fromBlock) {
-              cacheWithLatestFromBlock = c
-            }
-          }
-
-          storeCaches = [cacheWithLatestFromBlock]
-        }
-
-        storeCaches = storeCaches.map(c => {
-          const clone: any = { logs: [], metadata: JSON.parse(JSON.stringify(c.metadata)) }
-          if (c.logs.length > 200_000) {
-            // sort the logs by block number descending and keep only the latest 200k logs
-            c.logs.sort((a, b) => b.blockNumber - a.blockNumber)
-            clone.logs = c.logs.slice(0, 200_000)
-            const lastLog = clone.logs[clone.logs.length - 1]
-            clone.metadata.fromBlock = lastLog.blockNumber
-          }
-          return clone
-        })
+        storeCaches = trimCachesForStorage(storeCaches)
       }
 
       // we are skipping compression by default, so reads & writes are faster
@@ -337,6 +314,32 @@ export async function getLogs(
 /* -------------------------------------------------------------------------- */
 /*                           Utility helpers exported                         */
 /* -------------------------------------------------------------------------- */
+
+// keeps the newest range and at most maxLogs of its logs, narrowing the metadata to match what is kept
+export function trimCachesForStorage(caches: logCache[], maxLogs = 200_000): logCache[] {
+  if (!caches.length) return caches
+
+  let trimmed = caches
+  if (caches.length > 1) {
+    let cacheWithLatestFromBlock = caches[0]
+    for (const c of caches) {
+      if (c.metadata.fromBlock > cacheWithLatestFromBlock.metadata.fromBlock) {
+        cacheWithLatestFromBlock = c
+      }
+    }
+    trimmed = [cacheWithLatestFromBlock]
+  }
+
+  return trimmed.map(c => {
+    const clone: any = { logs: c.logs, metadata: JSON.parse(JSON.stringify(c.metadata)) }
+    if (c.logs.length > maxLogs) {
+      const sorted = [...c.logs].sort((a: any, b: any) => b.blockNumber - a.blockNumber)
+      clone.logs = sorted.slice(0, maxLogs)
+      clone.metadata.fromBlock = clone.logs[clone.logs.length - 1].blockNumber
+    }
+    return clone
+  })
+}
 
 export function toFilterTopic(topic: string): string {
   if (topic.startsWith("0x")) return topic;


### PR DESCRIPTION
Fixes #247.

The 300MB trim path in `addLogsToCache` built its clone with an empty log list and only ever filled it inside `if (c.logs.length > 200_000)`:

```ts
const clone: any = { logs: [], metadata: JSON.parse(JSON.stringify(c.metadata)) }
if (c.logs.length > 200_000) { ... clone.logs = c.logs.slice(0, 200_000) ... }
return clone
```

There is no `else`, so any cache entry at or under the cap was persisted as `logs: []` while `metadata` kept the original `fromBlock`/`toBlock`. On the next run the read path matches that range, filters an empty array and returns nothing, and the gap filler skips it because the metadata says it is covered — so the range reads as zero logs until the cache file is deleted. That the metadata is only narrowed in the >200k branch is the tell that the empty case was never intended.

The shape that makes it likely rather than theoretical: when several ranges are cached the code first collapses them to `[cacheWithLatestFromBlock]`, and a single range is very often under the cap, so the common outcome of tripping the threshold is one entry with every log dropped.

## the change

Default the clone to the logs it already holds, and only replace them when actually trimming. Pulled the block out into `trimCachesForStorage(caches, maxLogs)` so it can be tested without standing up a 300MB cache — the behaviour is otherwise unchanged, including keeping only the newest range and narrowing `fromBlock` to the oldest surviving log.

## tests

Four cases in `src/util/logs.test.ts`, no network:

- logs survive when the range is under the cap
- no cache is ever returned claiming a range it has no logs for
- over the cap, exactly `maxLogs` newest logs are kept and `fromBlock` moves to the oldest survivor
- with several ranges cached, only the newest is kept

Against the old logic 3 of the 4 fail; the trimming case passes on both, since that path was already correct. With the change all 4 pass, run twice.
