### PR TITLE
convertToBigInt: handle an exponent smaller than the mantissa instead of throwing

### DIFF
--- a/src/generalUtil.test.ts
+++ b/src/generalUtil.test.ts
@@ -239,6 +239,14 @@ test('convertToBigInt', () => {
   expect(convertToBigInt('0x0000000000000000000139C5FfeE6153a7b8678f')).toBe(BigInt('1481753159505255786375055'))
 })
 
+test('convertToBigInt - exponent smaller than the mantissa', () => {
+  expect(convertToBigInt('2.031945223e+5')).toBe(BigInt('203194'))
+  expect(convertToBigInt('1.2345e2')).toBe(BigInt('123'))
+  expect(convertToBigInt('1.23456789012345678e+10')).toBe(BigInt('12345678901'))
+  expect(convertToBigInt('-1.2345e2')).toBe(BigInt('-123'))
+  expect(convertToBigInt('1.5e+1')).toBe(BigInt('15'))
+})
+
 test("getHash", () => {
   // Test basic functionality
   const hash1 = getHash("test string");

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -22,7 +22,10 @@ export function convertToBigInt(value: any) {
       let exponent = +e;
 
       if (exponent >= 0) {
-        final = lead + (decimal || '') + '0'.repeat(exponent - (decimal || '').length);
+        const decimals = decimal || '';
+        final = exponent >= decimals.length
+          ? lead + decimals + '0'.repeat(exponent - decimals.length)
+          : lead + decimals.slice(0, exponent);
       } else {
         // NOTE: unforutenately BigInt doesn't support negative exponents, so this ends up being 0
         exponent = exponent * -1


### PR DESCRIPTION
`convertToBigInt` parses scientific notation, but only when the exponent is at least as long as the mantissa's decimals. When it is shorter the padding count goes negative and `String.prototype.repeat` throws:

```ts
final = lead + (decimal || '') + '0'.repeat(exponent - (decimal || '').length);
```

```
convertToBigInt('2.031e+22')            -> 20310000000000000000000
convertToBigInt('2.031945223e+5')       -> RangeError: Invalid count value: -4
convertToBigInt('1.2345e2')             -> RangeError: Invalid count value: -2
convertToBigInt('1.23456789012345678e+10') -> RangeError: Invalid count value: -7
```

The three that throw are all well-formed numbers the branch is meant to cover — `2.031945223e+5` is 203194.5223, so the answer is 203194.

The existing test only exercises the wide-exponent side (`'2.031e+22'`, `2.031945223e+22`), which is why it has not shown up.

## the change

Pad when the exponent is long enough, truncate when it is not:

```ts
const decimals = decimal || '';
final = exponent >= decimals.length
  ? lead + decimals + '0'.repeat(exponent - decimals.length)
  : lead + decimals.slice(0, exponent);
```

Truncation rather than rounding, to match what `BigInt` does with the rest of this function, and it keeps the sign right because the fractional digits are simply dropped: `-1.2345e2` gives `-123`.

Every input that works today is untouched — the new path only runs where the old one threw.

## tests

Added to the existing `convertToBigInt` test in `src/generalUtil.test.ts`:

```ts
expect(convertToBigInt('2.031945223e+5')).toBe(BigInt('203194'))
expect(convertToBigInt('1.2345e2')).toBe(BigInt('123'))
expect(convertToBigInt('1.23456789012345678e+10')).toBe(BigInt('12345678901'))
expect(convertToBigInt('-1.2345e2')).toBe(BigInt('-123'))
expect(convertToBigInt('1.5e+1')).toBe(BigInt('15'))
```

Fails on master with `RangeError: Invalid count value: -4`. `npx jest src/generalUtil.test.ts` is 20/20 with the change, run twice.

Worth saying where this does and does not bite: `String(someNumber)` only goes exponential at 1e21 and above, where the exponent always exceeds the ~17 mantissa digits, so a JS number cannot reach it. It is reachable from strings, which is what `sumSingleBalance` passes straight through from adapter and api responses.
