### PR TITLE
chainUtils: resolve dead chain keys against the freshly merged label map

### DIFF
--- a/src/util/chainUtils/index.ts
+++ b/src/util/chainUtils/index.ts
@@ -30,7 +30,10 @@ export async function updateData(): Promise<void> {
     for (const [label, value] of Object.entries(config.chainCoingeckoIds ?? {})) {
       const deadFrom = (value as any)?.deadFrom
       if (!deadFrom) continue
-      const key = getChainKeyFromLabel(label)
+      // resolve against the label map merged just above. getChainKeyFromLabel reads a cache built
+      // at import time, so a label added in this same run is invisible to it and falls back to a
+      // sluggified key that no chain uses
+      const key = (chainLabelsToKeyMap as any)[label] ?? getChainKeyFromLabel(label)
         ; (deadChains as any)[key] = deadFrom
     }
 

--- a/src/util/chainUtils/updateData.test.ts
+++ b/src/util/chainUtils/updateData.test.ts
@@ -1,0 +1,48 @@
+import fs from 'fs'
+import { updateData } from './index'
+
+// A label that only exists in the remote label map, not in the shipped data.json. This is the
+// shape that matters: api.llama.fi/config names a chain, and the key it maps to is only learned
+// in the same updateData run that reads the config.
+const REMOTE_LABEL = 'Zzz Test Chain'
+const REMOTE_KEY = 'zzztc'
+
+function mockResponses() {
+  return jest.spyOn(global as any, 'fetch').mockImplementation((url: any) => {
+    if (String(url).includes('chain-name-id-map-v2'))
+      return Promise.resolve({
+        json: async () => ({
+          chainKeyToChainLabelMap: { [REMOTE_KEY]: REMOTE_LABEL },
+          chainLabelsToKeyMap: { [REMOTE_LABEL]: REMOTE_KEY },
+        }),
+      } as any)
+
+    return Promise.resolve({
+      json: async () => ({
+        chainCoingeckoIds: { [REMOTE_LABEL]: { deadFrom: '2026-08-19' } },
+      }),
+    } as any)
+  })
+}
+
+test('updateData records deadFrom under the key the label maps to, not a sluggified fallback', async () => {
+  const fetchSpy = mockResponses()
+  let written: any
+  const writeSpy = jest
+    .spyOn(fs, 'writeFileSync')
+    .mockImplementation(((_path: any, data: any) => {
+      written = JSON.parse(data)
+    }) as any)
+
+  try {
+    await updateData()
+  } finally {
+    writeSpy.mockRestore()
+    fetchSpy.mockRestore()
+  }
+
+  expect(written).toBeDefined()
+  expect(written.deadChains[REMOTE_KEY]).toBe('2026-08-19')
+  // the fallback getChainKeyFromLabel produces for an unknown label, which is a key no chain uses
+  expect(written.deadChains['zzz_test_chain']).toBeUndefined()
+})


### PR DESCRIPTION
`updateData` merges the remote label map and then resolves each `config` label with `getChainKeyFromLabel`:

```ts
for (const [key, value] of Object.entries(remoteData.chainLabelsToKeyMap)) {
  (chainLabelsToKeyMap as any)[key] = value
}
...
const key = getChainKeyFromLabel(label)
  ; (deadChains as any)[key] = deadFrom
```

`getChainKeyFromLabel` reads `_chainLabelToChainIdCache`, which is built once at import time from the shipped `data.json`. The labels merged a few lines above are not in it, so they miss, and the function falls through to its last resort:

```ts
value = sluggifiedLabel.replace(/\-/g, '_') // try replacing - with _
```

That returns a key without checking whether any chain uses it.

## what it writes today

Running the real `updateData()` against master and the live endpoints, the `deadChains` part of the diff is:

```
+    "kujira": "2026-08-03",
+    "moonbeam": "2026-07-31",
+    "moonriver": "2026-07-31",
+    "winr_chain": "2026-05-01",
```

The first three are correct and are what #246 adds by hand. The fourth is not a chain. The same run writes `"WINR Chain": "winr"` into `chainLabelsToKeyMap` in the same file, so the output contradicts itself, and the real `winr` entry keeps whatever date it already had rather than being refreshed.

## why it is worth fixing rather than tidying up after

`WINR Chain` is the only config label with a `deadFrom` that misses today, so the immediate damage is one junk key. The exposure is the next one. Eight config labels are currently absent from the shipped map, and for several the correct key is nowhere near the slug:

| config label | real key | key `updateData` would write |
|---|---|---|
| MemeCore | `m` | `memecore` |
| Pi Network | `pi` | `pi_network` |
| BSV Blockchain | `bsv` | `bsv_blockchain` |
| Kaspa | `kaspa` | `kaspa` |

If any of those is marked dead, the `deadFrom` lands on a key nothing reads and the chain is never skipped. That is the failure #245 documents downstream: `dimension-adapters` gates on `getDeadChains()`, and a dead chain that is not in the list took eight adapters dark for four days when Moonbeam and Moonriver stopped producing blocks.

## the change

```ts
const key = (chainLabelsToKeyMap as any)[label] ?? getChainKeyFromLabel(label)
```

Prefer the map that was just merged, keep `getChainKeyFromLabel` as the fallback for a label in neither. Nothing about when or by whom `updateData` is called changes — it stays publish-time only. This is not #228: that one wanted `updateData` to refresh the runtime cache for callers, which was declined as intentional. This only changes what the publish-time regeneration writes into `data.json`.

## verification

Re-ran the real `updateData()` with the change against the live endpoints. `deadChains` gains exactly:

```
+    "kujira": "2026-08-03",
+    "moonbeam": "2026-07-31",
+    "moonriver": "2026-07-31",
```

`winr` reads `2026-05-01`, `winr_chain` is absent.

The added test mocks both fetches and `fs.writeFileSync`, so it neither hits the network nor rewrites `data.json`. It feeds a label that exists only in the remote map and asserts the `deadFrom` lands on the mapped key and not on the sluggified one. It fails on master with `Expected "2026-08-19", Received undefined`.

`npx jest src/util/chainUtils` is 69/69 and `npx tsc --noEmit` is clean.

No overlap with #246, which only touches `data.json` — that one fixes the three chains missing right now, this one fixes what the next regeneration does. Found by @0xshubhs, who flagged it at the end of #246 and left it alone there.
