### PR TITLE
tron: do not cache a failed getBalance for the life of the process

### DIFF
--- a/src/abi/tron.cache.test.ts
+++ b/src/abi/tron.cache.test.ts
@@ -1,0 +1,34 @@
+import * as common from "../util/common"
+import { getBalance } from "./tron"
+
+// unique per test so the module level balanceCache in tron.ts is not shared between cases
+const ADDRESS = 'TCacheProbe1111111111111111111111111'
+
+test('tron: a failed getBalance is not cached, the next call retries', async () => {
+  jest.spyOn(common, 'sleepRandom').mockResolvedValue(undefined as any)
+
+  let healthy = false
+  const postJson = jest.spyOn(common, 'postJson').mockImplementation(async () => {
+    if (!healthy) throw new Error('rpc down')
+    return { balance: 12_345_678 } as any
+  })
+
+  await expect(getBalance({ target: ADDRESS })).rejects.toThrow('All TRON RPCs are not working')
+  const callsAfterFailure = postJson.mock.calls.length
+  expect(callsAfterFailure).toBeGreaterThan(0)
+
+  // the RPC recovers
+  healthy = true
+  const res = await getBalance({ target: ADDRESS, decimals: 6 })
+
+  expect(res.output).toBe("12.345678")
+  // the retry actually went out to the network rather than being served the cached rejection
+  expect(postJson.mock.calls.length).toBeGreaterThan(callsAfterFailure)
+
+  // a successful response is still cached, so a repeat call does not hit the network again
+  const callsAfterSuccess = postJson.mock.calls.length
+  await getBalance({ target: ADDRESS, decimals: 6 })
+  expect(postJson.mock.calls.length).toBe(callsAfterSuccess)
+
+  postJson.mockRestore()
+})

--- a/src/abi/tron.ts
+++ b/src/abi/tron.ts
@@ -44,7 +44,14 @@ export async function getBalance(params: {
   if (!params.target) throw new Error('getBalance: target is required')
 
   const data = await limitRPCCalls(() => {
-    if (!balanceCache[params.target]) balanceCache[params.target] = post({ address: params.target, visible: true, }, '/wallet/getaccount')
+    if (!balanceCache[params.target])
+      // drop the entry if the request fails, otherwise the rejected promise is served to every
+      // later call for this address and the process never retries it
+      balanceCache[params.target] = post({ address: params.target, visible: true, }, '/wallet/getaccount')
+        .catch((e: any) => {
+          delete balanceCache[params.target]
+          throw e
+        })
     return balanceCache[params.target]
   })
 


### PR DESCRIPTION
`getBalance` memoises the in-flight request per address:

```ts
const data = await limitRPCCalls(() => {
  if (!balanceCache[params.target]) balanceCache[params.target] = post({ address: params.target, visible: true, }, '/wallet/getaccount')
  return balanceCache[params.target]
})
```

`post` walks every host in `TRON_WALLET_RPC` and throws when they have all failed:

```ts
throw new Error(shortenString(`All TRON RPCs are not working. Errors: ...`, 1500))
```

The rejected promise stays in `balanceCache`. Every later call for that address returns the same rejection, and no request is made, so one transient failure removes the address for the rest of the process even after TRON recovers. `balanceCache` is module level with no eviction, so nothing clears it.

`getBalances` maps over `getBalance`, so a single poisoned address keeps failing the whole batch.

## reproduced

Stubbing `postJson` to fail once and then succeed, on master:

```
first call error:          All TRON RPCs are not working. Errors: rpc down
second call after recovery: THREW: All TRON RPCs are not working. Errors: rpc down
postJson call count:        1
```

The second call never reached the network. The count stays at 1 because the cached rejection is returned directly.

## the change

Attach a `catch` that drops the entry and rethrows. Successful responses stay cached exactly as before, so the de-duplication this cache exists for is unchanged, and only the failure case is retryable.

## tests

`src/abi/tron.cache.test.ts`, no network. It stubs `postJson` to fail while every host is tried, asserts the call rejects, flips the stub to healthy, and asserts the next call returns a real balance and that a request actually went out. It also asserts a second successful call does not hit the network, so the caching behaviour is pinned rather than silently removed.

Fails on master, passes here. `npx tsc --noEmit` is clean.

## note on overlap

This touches `getBalance` in the same file as #240, a few lines above that PR's hunk. They are independent, this one changes the request path and that one the balance arithmetic, and whichever lands first the other is a trivial rebase.
