### PR TITLE
indexer: do not let the partial sync break block fall behind fromBlock

### DIFF
--- a/src/util/indexer.breakBlock.test.ts
+++ b/src/util/indexer.breakBlock.test.ts
@@ -1,0 +1,36 @@
+import { getIndexerBreakBlock } from "./indexer"
+
+// the partial-sync path splits a request into an indexer leg [fromBlock, breakBlock] and an RPC leg
+// [breakBlock + 1, toBlock]. breakBlock sits a fixed buffer behind the indexer head, so it has to be
+// checked against fromBlock or the RPC leg starts before the range the caller asked for.
+
+test('breakBlock sits a buffer behind the indexer head when the range is wide enough', () => {
+  expect(getIndexerBreakBlock(1000, 5000)).toBe(4950)
+  expect(getIndexerBreakBlock(1000, 5000, 10)).toBe(4990)
+})
+
+test('breakBlock is usable right down to the first block of the range', () => {
+  // the indexer leg becomes the single block [1000, 1000], which is still a valid range
+  expect(getIndexerBreakBlock(1000, 1050)).toBe(1000)
+  // one block further behind and there is nothing left for the indexer to answer
+  expect(getIndexerBreakBlock(1000, 1049)).toBeUndefined()
+})
+
+test('a short range with the indexer lagging inside it does not produce a break block', () => {
+  // fromBlock 1000, toBlock 1080, lastIndexedBlock 1045
+  // percentageMissing = (1080 - 1045) / (1080 - 1000) * 100 = 43.75, so this passes the >50 guard
+  // and reaches the split. 1045 - 50 = 995, which is behind fromBlock.
+  const percentageMissing = ((1080 - 1045) / (1080 - 1000)) * 100
+  expect(percentageMissing).toBeLessThanOrEqual(50)
+  expect(getIndexerBreakBlock(1000, 1045)).toBeUndefined()
+})
+
+test('whenever a break block is returned, the RPC leg never starts before fromBlock', () => {
+  const fromBlock = 1000
+  for (let lastIndexedBlock = 900; lastIndexedBlock <= 1200; lastIndexedBlock++) {
+    const breakBlock = getIndexerBreakBlock(fromBlock, lastIndexedBlock)
+    if (breakBlock === undefined) continue
+    expect(breakBlock).toBeGreaterThanOrEqual(fromBlock)
+    expect(breakBlock + 1).toBeGreaterThan(fromBlock)
+  }
+})

--- a/src/util/indexer.ts
+++ b/src/util/indexer.ts
@@ -96,6 +96,15 @@ const axiosInstances: { [version in IndexerVersion]: ReturnType<typeof axios.cre
   }),
 };
 
+const INDEXER_HEAD_BUFFER = 50;
+
+// last block the indexer leg may answer, keeping a small buffer behind the indexer head.
+// undefined means the buffer leaves nothing inside the requested range, so the indexer is unusable here
+export function getIndexerBreakBlock(fromBlock: number, lastIndexedBlock: number, buffer = INDEXER_HEAD_BUFFER): number | undefined {
+  const breakBlock = lastIndexedBlock - buffer;
+  return breakBlock < fromBlock ? undefined : breakBlock;
+}
+
 function checkIndexerConfig(version: IndexerVersion) {
   const { endpoint, apiKey } = indexerConfigs[version];
   if (!endpoint || !apiKey) throw new Error(`Llama Indexer (${version}) URL/api key is not set`);
@@ -379,7 +388,13 @@ export async function getLogs(options: IndexerGetLogsOptions): Promise<any[]> {
     if (ENV_CONSTANTS.GET_LOGS_INDEXER)
       debugLog(`Indexer only partially up to date for ${chain}. Last indexed block: ${lastIndexedBlock}, requested block: ${toBlock}, missing ${Number(percentageMissing).toFixed(2)}%. Pulling part of the logs through RPC calls.`);
 
-    const breakBlock = lastIndexedBlock - 50; // small buffer
+    const breakBlock = getIndexerBreakBlock(fromBlock, lastIndexedBlock);
+
+    // the buffer can push the break block behind the start of the requested range, which leaves the
+    // indexer nothing to answer and would send the RPC leg looking for blocks before fromBlock
+    if (breakBlock === undefined)
+      return getLogsParent({ ...options, fromBlock, toBlock, skipIndexer: true });
+
     const indexerLogs = await getLogs({ ...options, fromBlock, toBlock: breakBlock });
     const rpcLogs = await getLogsParent({ ...options, fromBlock: breakBlock + 1, toBlock, skipIndexer: true });
 


### PR DESCRIPTION
When the indexer is behind, but by no more than half the requested range, `getLogs` serves the request from both sources:

```ts
const breakBlock = lastIndexedBlock - 50; // small buffer
const indexerLogs = await getLogs({ ...options, fromBlock, toBlock: breakBlock });
const rpcLogs = await getLogsParent({ ...options, fromBlock: breakBlock + 1, toBlock, skipIndexer: true });
```

The two legs are meant to tile the range exactly: `[fromBlock, breakBlock]` from the indexer and `[breakBlock + 1, toBlock]` over RPC. That holds as long as `breakBlock` is inside the range, and it is never checked.

## when it is not

The buffer is a fixed 50 blocks, so a short range with the indexer lagging inside it pushes `breakBlock` behind the start:

```
fromBlock 1000, toBlock 1080, lastIndexedBlock 1045

percentageMissing = (1080 - 1045) / (1080 - 1000) * 100 = 43.75   passes the > 50 guard
breakBlock        = 1045 - 50 = 995

  indexer leg  [1000, 995]    inverted
  rpc leg      [996, 1080]    starts 4 blocks before the requested range
```

`getLogsParent` is `getLogs` from `logs.ts`, which filters on the bounds it is handed:

```ts
.filter((i: EventLog) => i.blockNumber >= fromBlock! && i.blockNumber <= toBlock!)
```

There is no clamp back to the caller's original window, so logs from before `fromBlock` are returned. For anything that sums over the result, that is over-counting on the low edge of the window.

Reaching the branch requires `toBlock - lastIndexedBlock <= (toBlock - fromBlock) / 2`, and `breakBlock < fromBlock` requires `lastIndexedBlock < fromBlock + 50`. Both together mean the range is under 100 blocks, so this is a narrow case rather than a common one.

## the change

`getIndexerBreakBlock` returns `undefined` when the buffer leaves nothing inside the range, and that case pulls the whole window over RPC rather than splitting it. That also removes the inverted indexer call, which the old code made in the same situation.

The same arithmetic bounds the fallback: it only runs for ranges under 100 blocks, so it cannot turn into a large RPC scan. For `flatten: false` the early return keeps the per-target bucket shape, since it is the same call the RPC leg already made.

## what is verified, and what is not

Verified: `src/util/indexer.breakBlock.test.ts`, four cases, no network. Wide ranges still get `lastIndexedBlock - buffer`; the boundary where the indexer leg collapses to the single block `[fromBlock, fromBlock]` is still allowed; one block further behind returns `undefined`; and a sweep over 300 values of `lastIndexedBlock` asserts the RPC leg never starts before `fromBlock` whenever a break block is returned. The reachability case above is pinned with its `percentageMissing` computed in the test rather than asserted from the description. `npx tsc --noEmit` is clean.

Not verified: I could not exercise the live partial-sync path. `checkIndexerConfig` needs `LLAMA_INDEXER_ENDPOINT` and `LLAMA_INDEXER_API_KEY`, which I do not have, so `src/util/indexer.test.ts` fails here with `Llama Indexer URL/api key is not set` — 11 failed / 5 passed, and `indexer.streaming.test.ts` 1 failed. Both are identical on unmodified master, run before and after, so they are pre-existing environment failures rather than anything this introduces. The argument for the fix is the arithmetic and the absence of a clamp in `logs.ts`, not an observed bad result from a real indexer.
