### PR TITLE
blocks: fix switch fallthrough that starts the nibiru search 600k blocks back

### DIFF
--- a/src/util/blocks.pruned.test.ts
+++ b/src/util/blocks.pruned.test.ts
@@ -1,0 +1,23 @@
+import { getPrunedChainFirstBlock, prunedChainBlockRetention } from "./blocks"
+
+// nibiru and evmos prune, so the block search starts a fixed distance behind the head. The
+// distance has to stay inside what the RPC still serves or the very first lookup fails.
+
+test('pruned chains start the search inside their retained window', () => {
+  // measured against evm-rpc.nibiru.fi at head 44,683,543: head - 400k is served,
+  // head - 600k returns "block not found: tendermint client failed to get block"
+  expect(getPrunedChainFirstBlock('nibiru', 44_683_543)).toBe(44_283_543)
+  expect(getPrunedChainFirstBlock('nibiru', 44_683_543)).not.toBe(44_083_543)
+
+  expect(getPrunedChainFirstBlock('evmos', 1_000_000)).toBe(800_000)
+})
+
+test('each pruned chain gets its own retention and only its own', () => {
+  expect(prunedChainBlockRetention.nibiru).toBe(400_000)
+  expect(prunedChainBlockRetention.evmos).toBe(200_000)
+})
+
+test('chains that do not prune have no offset', () => {
+  expect(getPrunedChainFirstBlock('ethereum', 20_000_000)).toBeUndefined()
+  expect(getPrunedChainFirstBlock('bsc', 40_000_000)).toBeUndefined()
+})

--- a/src/util/blocks.ts
+++ b/src/util/blocks.ts
@@ -133,6 +133,18 @@ function getExtraProvider(chain = "ethereum") {
 
 export const getLatestBlock = getCurrentChainBlock
 
+// chains whose RPCs prune old blocks, so the block search has to start inside the retained window
+export const prunedChainBlockRetention: { [chain: string]: number } = {
+  nibiru: 4 * 1e5, // nibiru holds only the last 400k blocks
+  evmos: 2 * 1e5,  // evmos holds only the last 200k blocks
+}
+
+// oldest block the chain's RPC can still be asked for, undefined when the chain does not prune
+export function getPrunedChainFirstBlock(chain: string, latestBlockNumber: number): number | undefined {
+  const retention = prunedChainBlockRetention[chain]
+  return retention === undefined ? undefined : latestBlockNumber - retention
+}
+
 const intialBlocks = {
   planq: 14000000,
   sei: 150023881,
@@ -223,14 +235,9 @@ async function _lookupBlock(
   try {
     let firstBlock, lastBlock
 
-    if (['evmos', 'nibiru'].includes(chain)) {
+    if (prunedChainBlockRetention[chain] !== undefined) {
       lastBlock = await getLatestBlock(chain)
-      let firstBlockNum = lastBlock.number
-      switch (chain) {
-        case 'nibiru': firstBlockNum -= 4 * 1e5// nibiru hold only the last 400k block data
-        case 'evmos': firstBlockNum -= 2 * 1e5// evmos hold only the last 200k block data
-      }
-      firstBlock = await fetchBlockFromProvider(firstBlockNum, chain)
+      firstBlock = await fetchBlockFromProvider(getPrunedChainFirstBlock(chain, lastBlock.number)!, chain)
     } else {
       [lastBlock, firstBlock] = await Promise.all([
         highBlock ? highBlock : getLatestBlock(chain),


### PR DESCRIPTION
`_lookupBlock` starts its search from a fixed distance behind the head on chains that prune. The branch used a `switch` with no `break`:

```ts
if (['evmos', 'nibiru'].includes(chain)) {
  lastBlock = await getLatestBlock(chain)
  let firstBlockNum = lastBlock.number
  switch (chain) {
    case 'nibiru': firstBlockNum -= 4 * 1e5// nibiru hold only the last 400k block data
    case 'evmos': firstBlockNum -= 2 * 1e5// evmos hold only the last 200k block data
  }
  firstBlock = await fetchBlockFromProvider(firstBlockNum, chain)
}
```

`nibiru` matches its case, subtracts 400k, then falls through into `evmos` and subtracts another 200k, so the search starts **600k** blocks back against a comment that says the chain retains 400k. `evmos` is the last case and gets the correct 200k.

`noFallthroughCasesInSwitch` is commented out in `tsconfig.json`, so the compiler never flagged it.

## what the chain actually serves

Both RPCs in `providers.json` for nibiru, at head 44,683,543:

| endpoint | head - 400k | head - 600k |
|---|---|---|
| `evm-rpc.nibiru.fi` | OK | `block not found: tendermint client failed to get block` |
| `evm-rpc.archive.nibiru.fi` | OK | OK |

So the retention comment in the code is right and the arithmetic is wrong.

## how visible it is, stated plainly

Not visible today. `lookupBlock(now - 2 days, { chain: 'nibiru' })` returns block 44,585,370 on this branch and 44,585,377 on master, both in about 2 seconds, because the archive endpoint answers when the other one does not.

What it costs is a request that cannot succeed. For `getBlock` the non archival RPC goes first: `_performAction` builds `runners`, shuffles everything except the primary, and then puts the primary back as the **second** runner (`LlamaProvider.ts:146`), since `noPlayingAround` is false for this method. So the first attempt of every historical nibiru lookup goes to `evm-rpc.nibiru.fi` for a block it has already pruned. It becomes a real failure if the archive endpoint is removed, rate limited or down, and the search also spans 50% more blocks than intended.

I am not claiming a broken number in production. The case for this is that the code contradicts its own comment and depends on a fallback to paper over it.

## the change

A retention map keyed by chain:

```ts
export const prunedChainBlockRetention: { [chain: string]: number } = {
  nibiru: 4 * 1e5, // nibiru holds only the last 400k blocks
  evmos: 2 * 1e5,  // evmos holds only the last 200k blocks
}
```

This also removes the separate `['evmos', 'nibiru']` list, which had to be kept in agreement with the switch by hand. If you would rather keep the diff to one line, adding `break` to the `nibiru` case fixes the behaviour on its own and I am happy to reduce it to that.

## tests

`src/util/blocks.pruned.test.ts`, three cases, no network. It pins nibiru to head - 400k using the measured head above and asserts it is not head - 600k, pins evmos to 200k, and asserts chains that do not prune get no offset. `npx tsc --noEmit` is clean.
