### PR TITLE
getLogs: do not extend the fetched range past the chain head

### DIFF
--- a/src/util/logs.buffer.test.ts
+++ b/src/util/logs.buffer.test.ts
@@ -1,0 +1,31 @@
+import { getBufferedToBlock } from "./logs"
+
+// getLogs widens the fetched range by 10 blocks in each direction. Forward, that has to stop at the
+// chain head: base RPCs answer a range ending past their latest block with
+// "block range extends beyond current head block" and "block N is beyond the latest block M of this
+// node", and when every RPC in the pool does that the whole call throws.
+
+test('the full buffer is used when the head is far enough ahead', () => {
+  expect(getBufferedToBlock(1000, 5000)).toBe(1010)
+  expect(getBufferedToBlock(1000, 1010)).toBe(1010)
+})
+
+test('the buffer stops at the head', () => {
+  expect(getBufferedToBlock(1000, 1003)).toBe(1003)
+  expect(getBufferedToBlock(1000, 1000)).toBe(1000)
+})
+
+test('a stale head never shrinks the range below what was requested', () => {
+  // getBlockNumber caches the current block for a minute, so the head can read behind toBlock
+  expect(getBufferedToBlock(1000, 990)).toBe(1000)
+  expect(getBufferedToBlock(1000, 0)).toBe(1000)
+})
+
+test('an unreadable head keeps the previous behaviour', () => {
+  expect(getBufferedToBlock(1000, undefined)).toBe(1010)
+})
+
+test('the buffer size is configurable and still clamped', () => {
+  expect(getBufferedToBlock(1000, 5000, 50)).toBe(1050)
+  expect(getBufferedToBlock(1000, 1020, 50)).toBe(1020)
+})

--- a/src/util/logs.ts
+++ b/src/util/logs.ts
@@ -16,6 +16,16 @@ import { enrichEthersArgsWithNamedProperties, padTopic32 } from "./logs.decode.s
 
 const currentVersion = "v3";
 
+const BLOCK_BUFFER = 10;
+
+// widen the fetched range forward by BLOCK_BUFFER, without asking for blocks the chain does not
+// have yet and without ever returning less than the caller asked for
+export function getBufferedToBlock(toBlock: number, head?: number, buffer = BLOCK_BUFFER): number {
+  const buffered = toBlock + buffer;
+  if (head === undefined) return buffered;
+  return Math.min(buffered, Math.max(toBlock, head));
+}
+
 /* -------------------------------------------------------------------------- */
 /*                                   Types                                    */
 /* -------------------------------------------------------------------------- */
@@ -209,8 +219,14 @@ export async function getLogs(
     if (debugMode) debugLog("adding logs to cache:", fromBlock, toBlock);
 
     if (fromBlock > toBlock) return;
-    fromBlock = Math.max(fromBlock - 10, 0); // avoid negative block
-    toBlock = toBlock + 10;
+    fromBlock = Math.max(fromBlock - BLOCK_BUFFER, 0); // avoid negative block
+
+    // the forward buffer must not run past the chain head. Several RPCs reject a range that ends
+    // beyond their latest block outright, and since every RPC in the pool rejects it the whole call
+    // fails. If the head cannot be read (halted chain, provider error) keep the previous behaviour.
+    let head: number | undefined
+    try { head = await getBlockNumber(chain) } catch (e) { }
+    toBlock = getBufferedToBlock(toBlock, head);
 
     if (debugMode) console.time(dbgKey);
 


### PR DESCRIPTION
`addLogsToCache` widens the range it fetches by 10 blocks in each direction:

```ts
fromBlock = Math.max(fromBlock - 10, 0); // avoid negative block
toBlock = toBlock + 10;
```

Backwards that is always safe. Forwards it asks for blocks the chain does not have yet whenever `toBlock` is near the head, and several RPCs reject such a range instead of returning what they do have:

```
block range extends beyond current head block: requested 50162452, head 50162449
  https://base.publicnode.com
block 50162452 is beyond the latest block 50162448 of this node, retry later
  https://base.rpc.sentio.xyz
```

`_performAction` tries the whole pool, so when they all answer that way the call throws.

## reproduced

Reading the head fresh from the provider each time and calling `getLogs` with `toBlock` set to it, USDC transfers on base, `skipCache: true`:

| | ok | threw |
|---|---|---|
| master, 10 attempts | 5 | 5 |
| this branch, 10 attempts | 10 | 0 |

It is intermittent by nature: it fails when the chain has not produced 10 more blocks between the caller resolving `toBlock` and the fetch going out, so a retry a few seconds later succeeds. Any caller asking for logs up to the current block is exposed, including anything that resolves `toBlock` from a current timestamp, since `_lookupBlock` short circuits to the latest block for a timestamp inside the last five minutes.

## the change

Clamp the forward buffer to the head:

```ts
export function getBufferedToBlock(toBlock: number, head?: number, buffer = BLOCK_BUFFER): number {
  const buffered = toBlock + buffer;
  if (head === undefined) return buffered;
  return Math.min(buffered, Math.max(toBlock, head));
}
```

Two details that the `Math.max` is there for:

- `getBlockNumber` with no timestamp goes through `getCurrentChainBlock`, which caches for a minute, so the head can legitimately read *behind* `toBlock`. The clamp must never return less than the caller asked for, or a stale head would start silently truncating real requests.
- reading the head can throw. `validateCurrentBlock` rejects a chain more than 60 minutes behind, which is exactly the halted chain case where `getLogs` still needs to behave as it does today. The read is wrapped and an unreadable head falls back to the old unclamped buffer.

The head lookup is one extra provider call per `addLogsToCache`, served from the one minute cache in `blocks.ts` for all but the first call per chain per minute. No circular import: `logs.ts` already imports `getBlockNumber` from `./blocks`, and `blocks.ts` does not import `logs.ts`.

## tests

`src/util/logs.buffer.test.ts`, five cases, no network: full buffer when the head is far enough ahead, buffer stopping exactly at the head, a stale head never shrinking the request, an unreadable head keeping the old behaviour, and a custom buffer size still clamped.

`npx tsc --noEmit` is clean. `src/util/logs.test.ts` passed fully on one run and had one network test flake on a second. That set is flaky independently of this change: three of them failed on one master run earlier today and passed on the next, and the full file is green on master.
